### PR TITLE
Add notification feature for subscription detail page

### DIFF
--- a/app/src/main/kotlin/dev/pott/abonity/app/AbonityApplication.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/AbonityApplication.kt
@@ -17,7 +17,6 @@ import dev.pott.abonity.app.firebase.setFirebaseDefaultCustomKeys
 import dev.pott.abonity.app.notification.SUBSCRIPTION_NOTIFICATION_CHANNEL_ID
 import dev.pott.abonity.app.notification.SubscriptionNotificationWorker
 import dev.pott.abonity.app.widget.work.SubscriptionWidgetUpdateWorker
-import dev.pott.abonity.core.ui.R as UiR
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -32,6 +31,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
+import dev.pott.abonity.core.ui.R as UiR
 
 private const val SUBSCRIPTION_WIDGET_WORK_ID = "SUBSCRIPTION_WIDGET_UPDATE"
 private const val SUBSCRIPTION_NOTIFICATION_WORK_ID = "SUBSCRIPTION_NOTIFICATION"

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -12,11 +12,11 @@ import dev.pott.abonity.app.R
 import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
 import dev.pott.abonity.core.domain.subscription.SubscriptionRepository
 import dev.pott.abonity.core.entity.subscription.PaymentType
-import dev.pott.abonity.core.ui.R as UiR
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import kotlin.time.Clock
+import dev.pott.abonity.core.ui.R as UiR
 
 const val SUBSCRIPTION_NOTIFICATION_CHANNEL_ID = "subscription_payment_reminders"
 
@@ -55,10 +55,12 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         val todayEpochDays = clock.todayIn(TimeZone.currentSystemDefault()).toEpochDays()
-        val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return Result.success()
+        val subscriptions =
+            repository.getSubscriptionsFlow().firstOrNull() ?: return Result.success()
         subscriptions.forEach { subscription ->
             val config = subscription.notificationConfig ?: return@forEach
-            val days = daysUntilNextPayment(subscription, todayEpochDays, calculator) ?: return@forEach
+            val days =
+                daysUntilNextPayment(subscription, todayEpochDays, calculator) ?: return@forEach
             if (days == config.daysBeforePayment) {
                 sendNotification(
                     subscriptionId = subscription.id.value.hashCode(),
@@ -75,7 +77,10 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
         subscriptionName: String,
         daysUntilPayment: Int,
     ) {
-        val title = appContext.getString(UiR.string.subscription_notification_title, subscriptionName)
+        val title = appContext.getString(
+            UiR.string.subscription_notification_title,
+            subscriptionName,
+        )
         val text = if (daysUntilPayment == 0) {
             appContext.getString(UiR.string.subscription_notification_text_today, subscriptionName)
         } else {
@@ -88,7 +93,10 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
         }
         val notificationManager = NotificationManagerCompat.from(appContext)
         if (!notificationManager.areNotificationsEnabled()) return
-        val notification = NotificationCompat.Builder(appContext, SUBSCRIPTION_NOTIFICATION_CHANNEL_ID)
+        val notification = NotificationCompat.Builder(
+            appContext,
+            SUBSCRIPTION_NOTIFICATION_CHANNEL_ID,
+        )
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(text)

--- a/core/entity/src/main/kotlin/dev/pott/abonity/core/entity/subscription/NotificationConfig.kt
+++ b/core/entity/src/main/kotlin/dev/pott/abonity/core/entity/subscription/NotificationConfig.kt
@@ -1,5 +1,3 @@
 package dev.pott.abonity.core.entity.subscription
 
-data class NotificationConfig(
-    val daysBeforePayment: Int,
-)
+data class NotificationConfig(val daysBeforePayment: Int)

--- a/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabaseMigrationTest.kt
+++ b/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabaseMigrationTest.kt
@@ -91,7 +91,8 @@ class AppDatabaseMigrationTest {
         openV2Database().use { db ->
             db.execSQL(
                 "INSERT INTO subscription_entity " +
-                    "(name, price, currency, first_payment_local_date, payment_type, notification_days_before) " +
+                    "(name, price, currency, first_payment_local_date, " +
+                    "payment_type, notification_days_before) " +
                     "VALUES ('New Sub', 4.99, 'USD', '2024-01-01', 'ONE_TIME', NULL)",
             )
             val cursor = db.query(
@@ -111,7 +112,8 @@ class AppDatabaseMigrationTest {
         openV2Database().use { db ->
             db.execSQL(
                 "INSERT INTO subscription_entity " +
-                    "(name, price, currency, first_payment_local_date, payment_type, notification_days_before) " +
+                    "(name, price, currency, first_payment_local_date, " +
+                    "payment_type, notification_days_before) " +
                     "VALUES ('Notified Sub', 9.99, 'EUR', '2024-06-01', 'ONE_TIME', 7)",
             )
             val cursor = db.query(
@@ -133,12 +135,14 @@ class AppDatabaseMigrationTest {
                     db.execSQL(CREATE_SUBSCRIPTION_ENTITY_V1)
                     db.execSQL(
                         "INSERT INTO subscription_entity " +
-                            "(name, description, price, currency, first_payment_local_date, payment_type, period_count, period) " +
+                            "(name, description, price, currency, " +
+                            "first_payment_local_date, payment_type, period_count, period) " +
                             "VALUES ('Periodic Sub', 'Monthly service', 9.99, 'EUR', '2020-02-02', 'PERIODICALLY', 1, 'MONTHS')",
                     )
                     db.execSQL(
                         "INSERT INTO subscription_entity " +
-                            "(name, description, price, currency, first_payment_local_date, payment_type) " +
+                            "(name, description, price, currency, " +
+                            "first_payment_local_date, payment_type) " +
                             "VALUES ('One Time Sub', 'One time purchase', 49.99, 'USD', '2021-05-15', 'ONE_TIME')",
                     )
                 }

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -124,8 +124,6 @@ fun NotificationConfigDialog(
     var period by remember { mutableStateOf(initialPeriod) }
     var periodExpanded by remember { mutableStateOf(false) }
 
-    val periodLabel = stringResource(period.labelRes())
-
     AlertDialog(
         icon = {
             Icon(
@@ -137,94 +135,23 @@ fun NotificationConfigDialog(
             Text(stringResource(id = R.string.subscription_notification_dialog_title))
         },
         text = {
-            Column {
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { isOff = true }
-                        .padding(vertical = 4.dp),
-                ) {
-                    RadioButton(selected = isOff, onClick = { isOff = true })
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = stringResource(id = R.string.subscription_notification_dialog_off),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
-                ) {
-                    RadioButton(selected = !isOff, onClick = { isOff = false })
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            OutlinedTextField(
-                                value = countText,
-                                onValueChange = { input ->
-                                    if (input.all { it.isDigit() }) {
-                                        countText = input
-                                        isOff = false
-                                    }
-                                },
-                                keyboardOptions = KeyboardOptions(
-                                    keyboardType = KeyboardType.Number,
-                                ),
-                                modifier = Modifier.weight(1f),
-                                singleLine = true,
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            ExposedDropdownMenuBox(
-                                expanded = periodExpanded,
-                                onExpandedChange = { periodExpanded = it },
-                            ) {
-                                OutlinedTextField(
-                                    value = periodLabel,
-                                    onValueChange = {},
-                                    readOnly = true,
-                                    trailingIcon = {
-                                        ExposedDropdownMenuDefaults.TrailingIcon(
-                                            expanded = periodExpanded,
-                                        )
-                                    },
-                                    modifier = Modifier.menuAnchor(
-                                        ExposedDropdownMenuAnchorType.PrimaryNotEditable,
-                                    ),
-                                    singleLine = true,
-                                )
-                                ExposedDropdownMenu(
-                                    expanded = periodExpanded,
-                                    onDismissRequest = { periodExpanded = false },
-                                ) {
-                                    NotificationPeriod.entries.forEach { p ->
-                                        DropdownMenuItem(
-                                            text = { Text(text = stringResource(p.labelRes())) },
-                                            onClick = {
-                                                period = p
-                                                periodExpanded = false
-                                                isOff = false
-                                            },
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = stringResource(
-                                id = R.string.subscription_notification_dialog_before_payment,
-                            ),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
+            NotificationDialogContent(
+                isOff = isOff,
+                countText = countText,
+                period = period,
+                periodExpanded = periodExpanded,
+                onIsOffChange = { isOff = it },
+                onCountTextChange = { input, newIsOff ->
+                    countText = input
+                    isOff = newIsOff
+                },
+                onPeriodChange = { p, expanded, newIsOff ->
+                    period = p
+                    periodExpanded = expanded
+                    isOff = newIsOff
+                },
+                onPeriodExpandedChange = { periodExpanded = it },
+            )
         },
         confirmButton = {
             TextButton(
@@ -264,6 +191,100 @@ fun NotificationConfigDialog(
                 context.startActivity(intent)
             },
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NotificationDialogContent(
+    isOff: Boolean,
+    countText: String,
+    period: NotificationPeriod,
+    periodExpanded: Boolean,
+    onIsOffChange: (Boolean) -> Unit,
+    onCountTextChange: (input: String, isOff: Boolean) -> Unit,
+    onPeriodChange: (period: NotificationPeriod, expanded: Boolean, isOff: Boolean) -> Unit,
+    onPeriodExpandedChange: (Boolean) -> Unit,
+) {
+    val periodLabel = stringResource(period.labelRes())
+    Column {
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onIsOffChange(true) }
+                .padding(vertical = 4.dp),
+        ) {
+            RadioButton(selected = isOff, onClick = { onIsOffChange(true) })
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(id = R.string.subscription_notification_dialog_off),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
+        ) {
+            RadioButton(selected = !isOff, onClick = { onIsOffChange(false) })
+            Spacer(modifier = Modifier.width(8.dp))
+            Column {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    OutlinedTextField(
+                        value = countText,
+                        onValueChange = { input ->
+                            if (input.all { it.isDigit() }) {
+                                onCountTextChange(input, false)
+                            }
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.weight(1f),
+                        singleLine = true,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    ExposedDropdownMenuBox(
+                        expanded = periodExpanded,
+                        onExpandedChange = onPeriodExpandedChange,
+                    ) {
+                        OutlinedTextField(
+                            value = periodLabel,
+                            onValueChange = {},
+                            readOnly = true,
+                            trailingIcon = {
+                                ExposedDropdownMenuDefaults.TrailingIcon(expanded = periodExpanded)
+                            },
+                            modifier = Modifier.menuAnchor(
+                                ExposedDropdownMenuAnchorType.PrimaryNotEditable,
+                            ),
+                            singleLine = true,
+                        )
+                        ExposedDropdownMenu(
+                            expanded = periodExpanded,
+                            onDismissRequest = { onPeriodExpandedChange(false) },
+                        ) {
+                            NotificationPeriod.entries.forEach { p ->
+                                DropdownMenuItem(
+                                    text = { Text(text = stringResource(p.labelRes())) },
+                                    onClick = { onPeriodChange(p, false, false) },
+                                )
+                            }
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(
+                        id = R.string.subscription_notification_dialog_before_payment,
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }
 

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -53,19 +53,24 @@ private enum class NotificationPeriod {
 private const val DAYS_IN_WEEK = 7
 private const val APPROX_DAYS_IN_MONTH = 30
 
-private fun NotificationPeriod.labelRes(): Int = when (this) {
-    NotificationPeriod.DAYS -> R.string.subscription_notification_dialog_period_days
-    NotificationPeriod.WEEKS -> R.string.subscription_notification_dialog_period_weeks
-    NotificationPeriod.MONTHS -> R.string.subscription_notification_dialog_period_months
-}
+private fun NotificationPeriod.labelRes(): Int =
+    when (this) {
+        NotificationPeriod.DAYS -> R.string.subscription_notification_dialog_period_days
+        NotificationPeriod.WEEKS -> R.string.subscription_notification_dialog_period_weeks
+        NotificationPeriod.MONTHS -> R.string.subscription_notification_dialog_period_months
+    }
 
 private fun initialPeriodAndCount(daysBeforePayment: Int?): Pair<NotificationPeriod, Int> =
     when {
         daysBeforePayment == null -> Pair(NotificationPeriod.DAYS, 1)
-        daysBeforePayment % APPROX_DAYS_IN_MONTH == 0 && daysBeforePayment >= APPROX_DAYS_IN_MONTH ->
+
+        daysBeforePayment % APPROX_DAYS_IN_MONTH == 0 &&
+            daysBeforePayment >= APPROX_DAYS_IN_MONTH ->
             Pair(NotificationPeriod.MONTHS, daysBeforePayment / APPROX_DAYS_IN_MONTH)
+
         daysBeforePayment % DAYS_IN_WEEK == 0 && daysBeforePayment >= DAYS_IN_WEEK ->
             Pair(NotificationPeriod.WEEKS, daysBeforePayment / DAYS_IN_WEEK)
+
         else -> Pair(NotificationPeriod.DAYS, daysBeforePayment)
     }
 


### PR DESCRIPTION
- Add NotificationConfig entity to store days-before-payment setting
- Add notificationConfig field to Subscription entity (nullable, null = disabled)
- Update Room DB to version 2 with MIGRATION_1_2 for new column
- Add notification bell icon to subscription detail toolbar actions
- Create NotificationConfigDialog with options: off, same day, 1/2/3/7 days before
- Update DetailViewModel with setNotificationConfig method for persistence
- Create SubscriptionNotificationWorker (HiltWorker) that runs daily at 8 AM
  and sends one notification per subscription due for notification
- Register notification worker in AbonityApplication with 8 AM schedule
- Create notification channel for payment reminders

https://claude.ai/code/session_01X8sVBakB31jcUKj8TGXC4y