### PR TITLE
Add notification feature for subscription detail page

### DIFF
--- a/app/src/main/kotlin/dev/pott/abonity/app/AbonityApplication.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/AbonityApplication.kt
@@ -23,7 +23,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atTime
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import java.util.concurrent.TimeUnit
@@ -91,25 +93,14 @@ class AbonityApplication :
                     workRequest,
                 )
 
-            val nowMillis = now.toEpochMilliseconds()
-            val notificationStartTime = now
-                .toLocalDateTime(timeZone)
-                .let { currentDateTime ->
-                    val todayAt8 = LocalDateTime(
-                        currentDateTime.year,
-                        currentDateTime.month,
-                        currentDateTime.day,
-                        NOTIFICATION_WORK_HOUR,
-                        0,
-                        0,
-                    ).toInstant(timeZone)
-                    val todayAt8Millis = todayAt8.toEpochMilliseconds()
-                    if (todayAt8Millis > nowMillis) todayAt8Millis else todayAt8.plus(1.days).toEpochMilliseconds()
-                }
+            val todayAt8 = now.toLocalDateTime(timeZone).date
+                .atTime(LocalTime(NOTIFICATION_WORK_HOUR, 0))
+                .toInstant(timeZone)
+            val notificationStartTime = if (todayAt8 > now) todayAt8 else todayAt8.plus(1.days)
 
             val notificationWorkRequest =
                 PeriodicWorkRequestBuilder<SubscriptionNotificationWorker>(1L, TimeUnit.DAYS)
-                    .setNextScheduleTimeOverride(notificationStartTime)
+                    .setNextScheduleTimeOverride(notificationStartTime.toEpochMilliseconds())
                     .build()
 
             WorkManager

--- a/app/src/main/kotlin/dev/pott/abonity/app/AbonityApplication.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/AbonityApplication.kt
@@ -1,6 +1,8 @@
 package dev.pott.abonity.app
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -12,7 +14,10 @@ import co.touchlab.kermit.Logger
 import co.touchlab.kermit.crashlytics.CrashlyticsLogWriter
 import dagger.hilt.android.HiltAndroidApp
 import dev.pott.abonity.app.firebase.setFirebaseDefaultCustomKeys
+import dev.pott.abonity.app.notification.SUBSCRIPTION_NOTIFICATION_CHANNEL_ID
+import dev.pott.abonity.app.notification.SubscriptionNotificationWorker
 import dev.pott.abonity.app.widget.work.SubscriptionWidgetUpdateWorker
+import dev.pott.abonity.core.ui.R as UiR
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -27,6 +32,8 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 
 private const val SUBSCRIPTION_WIDGET_WORK_ID = "SUBSCRIPTION_WIDGET_UPDATE"
+private const val SUBSCRIPTION_NOTIFICATION_WORK_ID = "SUBSCRIPTION_NOTIFICATION"
+private const val NOTIFICATION_WORK_HOUR = 8
 
 @HiltAndroidApp
 class AbonityApplication :
@@ -50,6 +57,7 @@ class AbonityApplication :
         Logger.setLogWriters(LogcatWriter(), CrashlyticsLogWriter())
         super.onCreate()
         trackingServiceManager.init()
+        createNotificationChannel()
         scope.launch {
             val now = clock.now()
             val timeZone = TimeZone.currentSystemDefault()
@@ -82,6 +90,47 @@ class AbonityApplication :
                     ExistingPeriodicWorkPolicy.UPDATE,
                     workRequest,
                 )
+
+            val nowMillis = now.toEpochMilliseconds()
+            val notificationStartTime = now
+                .toLocalDateTime(timeZone)
+                .let { currentDateTime ->
+                    val todayAt8 = LocalDateTime(
+                        currentDateTime.year,
+                        currentDateTime.month,
+                        currentDateTime.day,
+                        NOTIFICATION_WORK_HOUR,
+                        0,
+                        0,
+                    ).toInstant(timeZone)
+                    val todayAt8Millis = todayAt8.toEpochMilliseconds()
+                    if (todayAt8Millis > nowMillis) todayAt8Millis else todayAt8.plus(1.days).toEpochMilliseconds()
+                }
+
+            val notificationWorkRequest =
+                PeriodicWorkRequestBuilder<SubscriptionNotificationWorker>(1L, TimeUnit.DAYS)
+                    .setNextScheduleTimeOverride(notificationStartTime)
+                    .build()
+
+            WorkManager
+                .getInstance(this@AbonityApplication)
+                .enqueueUniquePeriodicWork(
+                    SUBSCRIPTION_NOTIFICATION_WORK_ID,
+                    ExistingPeriodicWorkPolicy.UPDATE,
+                    notificationWorkRequest,
+                )
+        }
+    }
+
+    private fun createNotificationChannel() {
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        if (manager.getNotificationChannel(SUBSCRIPTION_NOTIFICATION_CHANNEL_ID) == null) {
+            val channel = NotificationChannel(
+                SUBSCRIPTION_NOTIFICATION_CHANNEL_ID,
+                getString(UiR.string.subscription_notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
+            manager.createNotificationChannel(channel)
         }
     }
 

--- a/app/src/main/kotlin/dev/pott/abonity/app/AbonityApplication.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/AbonityApplication.kt
@@ -3,6 +3,7 @@ package dev.pott.abonity.app
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.os.Build
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -17,7 +18,6 @@ import dev.pott.abonity.app.firebase.setFirebaseDefaultCustomKeys
 import dev.pott.abonity.app.notification.SUBSCRIPTION_NOTIFICATION_CHANNEL_ID
 import dev.pott.abonity.app.notification.SubscriptionNotificationWorker
 import dev.pott.abonity.app.widget.work.SubscriptionWidgetUpdateWorker
-import dev.pott.abonity.core.ui.R as UiR
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -32,6 +32,8 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+import dev.pott.abonity.core.ui.R as UiR
 
 private const val SUBSCRIPTION_WIDGET_WORK_ID = "SUBSCRIPTION_WIDGET_UPDATE"
 private const val SUBSCRIPTION_NOTIFICATION_WORK_ID = "SUBSCRIPTION_NOTIFICATION"
@@ -60,60 +62,72 @@ class AbonityApplication :
         super.onCreate()
         trackingServiceManager.init()
         createNotificationChannel()
+        scheduleWork()
+    }
+
+    private fun scheduleWork() {
         scope.launch {
             val now = clock.now()
             val timeZone = TimeZone.currentSystemDefault()
-            val startOfNextDay = now
-                .plus(1.days)
-                .toLocalDateTime(timeZone)
-                .let {
-                    LocalDateTime(
-                        it.year,
-                        it.month,
-                        it.day,
-                        0,
-                        0,
-                        0,
-                    ).toInstant(timeZone)
-                }.toEpochMilliseconds()
-
-            val workRequestBuilder = PeriodicWorkRequestBuilder<SubscriptionWidgetUpdateWorker>(
-                1L,
-                TimeUnit.DAYS,
-            )
-            val workRequest = workRequestBuilder
-                .setNextScheduleTimeOverride(startOfNextDay)
-                .build()
-
-            WorkManager
-                .getInstance(this@AbonityApplication)
-                .enqueueUniquePeriodicWork(
-                    SUBSCRIPTION_WIDGET_WORK_ID,
-                    ExistingPeriodicWorkPolicy.UPDATE,
-                    workRequest,
-                )
-
-            val todayAt8 = now.toLocalDateTime(timeZone).date
-                .atTime(LocalTime(NOTIFICATION_WORK_HOUR, 0))
-                .toInstant(timeZone)
-            val notificationStartTime = if (todayAt8 > now) todayAt8 else todayAt8.plus(1.days)
-
-            val notificationWorkRequest =
-                PeriodicWorkRequestBuilder<SubscriptionNotificationWorker>(1L, TimeUnit.DAYS)
-                    .setNextScheduleTimeOverride(notificationStartTime.toEpochMilliseconds())
-                    .build()
-
-            WorkManager
-                .getInstance(this@AbonityApplication)
-                .enqueueUniquePeriodicWork(
-                    SUBSCRIPTION_NOTIFICATION_WORK_ID,
-                    ExistingPeriodicWorkPolicy.UPDATE,
-                    notificationWorkRequest,
-                )
+            scheduleWidgetWorker(now, timeZone)
+            scheduleNotificationWorker(now, timeZone)
         }
     }
 
+    private fun scheduleWidgetWorker(now: Instant, timeZone: TimeZone) {
+        val startOfNextDay = now
+            .plus(1.days)
+            .toLocalDateTime(timeZone)
+            .let {
+                LocalDateTime(
+                    it.year,
+                    it.month,
+                    it.day,
+                    0,
+                    0,
+                    0,
+                ).toInstant(timeZone)
+            }.toEpochMilliseconds()
+
+        val workRequestBuilder = PeriodicWorkRequestBuilder<SubscriptionWidgetUpdateWorker>(
+            1L,
+            TimeUnit.DAYS,
+        )
+        val workRequest = workRequestBuilder
+            .setNextScheduleTimeOverride(startOfNextDay)
+            .build()
+
+        WorkManager
+            .getInstance(this@AbonityApplication)
+            .enqueueUniquePeriodicWork(
+                SUBSCRIPTION_WIDGET_WORK_ID,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                workRequest,
+            )
+    }
+
+    private fun scheduleNotificationWorker(now: Instant, timeZone: TimeZone) {
+        val todayAt8 = now.toLocalDateTime(timeZone).date
+            .atTime(LocalTime(NOTIFICATION_WORK_HOUR, 0))
+            .toInstant(timeZone)
+        val notificationStartTime = if (todayAt8 > now) todayAt8 else todayAt8.plus(1.days)
+
+        val notificationWorkRequest =
+            PeriodicWorkRequestBuilder<SubscriptionNotificationWorker>(1L, TimeUnit.DAYS)
+                .setNextScheduleTimeOverride(notificationStartTime.toEpochMilliseconds())
+                .build()
+
+        WorkManager
+            .getInstance(this@AbonityApplication)
+            .enqueueUniquePeriodicWork(
+                SUBSCRIPTION_NOTIFICATION_WORK_ID,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                notificationWorkRequest,
+            )
+    }
+
     private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         if (manager.getNotificationChannel(SUBSCRIPTION_NOTIFICATION_CHANNEL_ID) == null) {
             val channel = NotificationChannel(

--- a/app/src/main/kotlin/dev/pott/abonity/app/di/CoreModule.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/di/CoreModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dev.pott.abonity.app.firebase.FirebaseRemoteConfigDataSource
+import dev.pott.abonity.app.notification.WorkManagerSubscriptionNotificationScheduler
 import dev.pott.abonity.core.domain.config.ConfigRepository
 import dev.pott.abonity.core.domain.config.ConfigRepositoryImpl
 import dev.pott.abonity.core.domain.config.LocalConfigDataSource
@@ -22,6 +23,7 @@ import dev.pott.abonity.core.domain.subscription.CategoryLocalDataSource
 import dev.pott.abonity.core.domain.subscription.CategoryRepository
 import dev.pott.abonity.core.domain.subscription.CategoryRepositoryImpl
 import dev.pott.abonity.core.domain.subscription.SubscriptionLocalDataSource
+import dev.pott.abonity.core.domain.subscription.SubscriptionNotificationScheduler
 import dev.pott.abonity.core.domain.subscription.SubscriptionRepository
 import dev.pott.abonity.core.domain.subscription.SubscriptionRepositoryImpl
 import dev.pott.abonity.core.local.legal.LegalDataStoreDataSource
@@ -78,4 +80,9 @@ interface CoreModule {
 
     @Binds
     fun bindLocalConfigDataSource(impl: FirebaseRemoteConfigDataSource): LocalConfigDataSource
+
+    @Binds
+    fun bindSubscriptionNotificationScheduler(
+        impl: WorkManagerSubscriptionNotificationScheduler,
+    ): SubscriptionNotificationScheduler
 }

--- a/app/src/main/kotlin/dev/pott/abonity/app/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/di/DatabaseModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dev.pott.abonity.core.local.subscription.db.AppDatabase
+import dev.pott.abonity.core.local.subscription.db.MIGRATION_1_2
 import javax.inject.Singleton
 
 private const val APP_DATABASE = "app-database"
@@ -24,6 +25,7 @@ object DatabaseModule {
             context,
             AppDatabase::class.java,
             APP_DATABASE,
-        ).fallbackToDestructiveMigration(dropAllTables = true)
+        ).addMigrations(MIGRATION_1_2)
+            .fallbackToDestructiveMigration(dropAllTables = true)
             .build()
 }

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -86,6 +86,8 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
                 daysUntilPayment,
             )
         }
+        val notificationManager = NotificationManagerCompat.from(appContext)
+        if (!notificationManager.areNotificationsEnabled()) return
         val notification = NotificationCompat.Builder(appContext, SUBSCRIPTION_NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentTitle(title)
@@ -93,6 +95,6 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .build()
-        NotificationManagerCompat.from(appContext).notify(subscriptionId, notification)
+        notificationManager.notify(subscriptionId, notification)
     }
 }

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -1,0 +1,94 @@
+package dev.pott.abonity.app.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dev.pott.abonity.app.R
+import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
+import dev.pott.abonity.core.domain.subscription.SubscriptionRepository
+import dev.pott.abonity.core.entity.subscription.PaymentType
+import dev.pott.abonity.core.ui.R as UiR
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import kotlin.time.Clock
+
+const val SUBSCRIPTION_NOTIFICATION_CHANNEL_ID = "subscription_payment_reminders"
+
+@HiltWorker
+class SubscriptionNotificationWorker @AssistedInject constructor(
+    @Assisted private val appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val repository: SubscriptionRepository,
+    private val calculator: PaymentInfoCalculator,
+    private val clock: Clock,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        ensureNotificationChannel()
+        val today = clock.todayIn(TimeZone.currentSystemDefault())
+        val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return Result.success()
+        subscriptions.forEach { subscription ->
+            val config = subscription.notificationConfig ?: return@forEach
+            val paymentType = subscription.paymentInfo.type
+            val nextPayment = if (paymentType is PaymentType.Periodic) {
+                calculator.getNextDateByType(paymentType)
+            } else {
+                subscription.paymentInfo.firstPayment
+            }
+            val daysUntilPayment = (nextPayment.toEpochDays() - today.toEpochDays()).toInt()
+            if (daysUntilPayment == config.daysBeforePayment) {
+                sendNotification(
+                    subscriptionId = subscription.id.value.toInt(),
+                    subscriptionName = subscription.name,
+                    daysUntilPayment = daysUntilPayment,
+                )
+            }
+        }
+        return Result.success()
+    }
+
+    private fun ensureNotificationChannel() {
+        val manager = appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (manager.getNotificationChannel(SUBSCRIPTION_NOTIFICATION_CHANNEL_ID) == null) {
+            val channel = NotificationChannel(
+                SUBSCRIPTION_NOTIFICATION_CHANNEL_ID,
+                appContext.getString(UiR.string.subscription_notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun sendNotification(
+        subscriptionId: Int,
+        subscriptionName: String,
+        daysUntilPayment: Int,
+    ) {
+        val title = appContext.getString(UiR.string.subscription_notification_title, subscriptionName)
+        val text = if (daysUntilPayment == 0) {
+            appContext.getString(UiR.string.subscription_notification_text_today, subscriptionName)
+        } else {
+            appContext.getString(
+                UiR.string.subscription_notification_text_days,
+                subscriptionName,
+                daysUntilPayment,
+            )
+        }
+        val notification = NotificationCompat.Builder(appContext, SUBSCRIPTION_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .build()
+        NotificationManagerCompat.from(appContext).notify(subscriptionId, notification)
+    }
+}

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -54,7 +54,7 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
-        val todayEpochDays = clock.todayIn(TimeZone.currentSystemDefault()).toEpochDays()
+        val todayEpochDays = clock.todayIn(TimeZone.currentSystemDefault()).toEpochDays().toInt()
         val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return Result.success()
         subscriptions.forEach { subscription ->
             val config = subscription.notificationConfig ?: return@forEach

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -1,7 +1,9 @@
 package dev.pott.abonity.app.notification
 
 import android.Manifest
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.annotation.RequiresPermission
 import androidx.core.app.ActivityCompat
@@ -12,6 +14,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import dev.pott.abonity.app.MainActivity
 import dev.pott.abonity.app.R
 import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
 import dev.pott.abonity.core.domain.subscription.SubscriptionRepository
@@ -54,7 +57,8 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
         val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return
         subscriptions.forEach { subscription ->
             val config = subscription.notificationConfig ?: return@forEach
-            val days = daysUntilNextPayment(subscription, todayEpochDays, calculator) ?: return@forEach
+            val days =
+                daysUntilNextPayment(subscription, todayEpochDays, calculator) ?: return@forEach
             if (days == config.daysBeforePayment) {
                 sendNotification(
                     subscriptionId = subscription.id.value,
@@ -87,6 +91,14 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
         }
         val notificationManager = NotificationManagerCompat.from(appContext)
         if (!notificationManager.areNotificationsEnabled()) return
+        val contentIntent = PendingIntent.getActivity(
+            appContext,
+            subscriptionId.hashCode(),
+            Intent(appContext, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
         val notification = NotificationCompat.Builder(
             appContext,
             SUBSCRIPTION_NOTIFICATION_CHANNEL_ID,
@@ -94,6 +106,7 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(text)
+            .setContentIntent(contentIntent)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .build()

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -22,6 +22,26 @@ import kotlin.time.Clock
 
 const val SUBSCRIPTION_NOTIFICATION_CHANNEL_ID = "subscription_payment_reminders"
 
+/**
+ * Returns the number of days until the next payment for [subscription] relative to [todayEpochDays],
+ * or null if the subscription has no notification config.
+ * A result of 0 means the payment is due today.
+ */
+internal fun daysUntilNextPayment(
+    subscription: dev.pott.abonity.core.entity.subscription.Subscription,
+    todayEpochDays: Int,
+    calculator: PaymentInfoCalculator,
+): Int? {
+    subscription.notificationConfig ?: return null
+    val paymentType = subscription.paymentInfo.type
+    val nextPayment = if (paymentType is PaymentType.Periodic) {
+        calculator.getNextDateByType(paymentType)
+    } else {
+        subscription.paymentInfo.firstPayment
+    }
+    return (nextPayment.toEpochDays() - todayEpochDays).toInt()
+}
+
 @HiltWorker
 class SubscriptionNotificationWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
@@ -33,22 +53,16 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         ensureNotificationChannel()
-        val today = clock.todayIn(TimeZone.currentSystemDefault())
+        val todayEpochDays = clock.todayIn(TimeZone.currentSystemDefault()).toEpochDays()
         val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return Result.success()
         subscriptions.forEach { subscription ->
             val config = subscription.notificationConfig ?: return@forEach
-            val paymentType = subscription.paymentInfo.type
-            val nextPayment = if (paymentType is PaymentType.Periodic) {
-                calculator.getNextDateByType(paymentType)
-            } else {
-                subscription.paymentInfo.firstPayment
-            }
-            val daysUntilPayment = (nextPayment.toEpochDays() - today.toEpochDays()).toInt()
-            if (daysUntilPayment == config.daysBeforePayment) {
+            val days = daysUntilNextPayment(subscription, todayEpochDays, calculator) ?: return@forEach
+            if (days == config.daysBeforePayment) {
                 sendNotification(
                     subscriptionId = subscription.id.value.toInt(),
                     subscriptionName = subscription.name,
-                    daysUntilPayment = daysUntilPayment,
+                    daysUntilPayment = days,
                 )
             }
         }

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -1,6 +1,10 @@
 package dev.pott.abonity.app.notification
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
+import androidx.annotation.RequiresPermission
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.work.HiltWorker
@@ -12,37 +16,14 @@ import dev.pott.abonity.app.R
 import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
 import dev.pott.abonity.core.domain.subscription.SubscriptionRepository
 import dev.pott.abonity.core.entity.subscription.PaymentType
-import dev.pott.abonity.core.ui.R as UiR
+import dev.pott.abonity.core.entity.subscription.Subscription
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import kotlin.time.Clock
+import dev.pott.abonity.core.ui.R as UiR
 
 const val SUBSCRIPTION_NOTIFICATION_CHANNEL_ID = "subscription_payment_reminders"
-
-/**
- * Returns the number of days until the next payment for [subscription] relative to [todayEpochDays],
- * or null if the subscription has no notification config.
- * A result of 0 means the payment is due today.
- */
-internal fun daysUntilNextPayment(
-    subscription: dev.pott.abonity.core.entity.subscription.Subscription,
-    todayEpochDays: Long,
-    calculator: PaymentInfoCalculator,
-): Int? {
-    subscription.notificationConfig ?: return null
-    val paymentType = subscription.paymentInfo.type
-    val nextPayment = if (paymentType is PaymentType.Periodic) {
-        var candidate = subscription.paymentInfo.firstPayment
-        while (candidate.toEpochDays() < todayEpochDays) {
-            candidate = calculator.getNextDateByType(paymentType, candidate)
-        }
-        candidate
-    } else {
-        subscription.paymentInfo.firstPayment
-    }
-    return (nextPayment.toEpochDays() - todayEpochDays).toInt()
-}
 
 @HiltWorker
 class SubscriptionNotificationWorker @AssistedInject constructor(
@@ -54,28 +35,46 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
+        if (ActivityCompat.checkSelfPermission(
+                appContext,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return Result.success()
+        }
+
+        sendNotificationForAllSubscriptions()
+
+        return Result.success()
+    }
+
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    private suspend fun sendNotificationForAllSubscriptions() {
         val todayEpochDays = clock.todayIn(TimeZone.currentSystemDefault()).toEpochDays()
-        val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return Result.success()
+        val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return
         subscriptions.forEach { subscription ->
             val config = subscription.notificationConfig ?: return@forEach
-            val days = daysUntilNextPayment(subscription, todayEpochDays, calculator) ?: return@forEach
+            val days = daysUntilNextPayment(subscription, todayEpochDays, calculator)
             if (days == config.daysBeforePayment) {
                 sendNotification(
-                    subscriptionId = subscription.id.value.hashCode(),
+                    subscriptionId = subscription.id.value,
                     subscriptionName = subscription.name,
                     daysUntilPayment = days,
                 )
             }
         }
-        return Result.success()
     }
 
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
     private fun sendNotification(
-        subscriptionId: Int,
+        subscriptionId: Long,
         subscriptionName: String,
         daysUntilPayment: Int,
     ) {
-        val title = appContext.getString(UiR.string.subscription_notification_title, subscriptionName)
+        val title = appContext.getString(
+            UiR.string.subscription_notification_title,
+            subscriptionName,
+        )
         val text = if (daysUntilPayment == 0) {
             appContext.getString(UiR.string.subscription_notification_text_today, subscriptionName)
         } else {
@@ -88,13 +87,39 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
         }
         val notificationManager = NotificationManagerCompat.from(appContext)
         if (!notificationManager.areNotificationsEnabled()) return
-        val notification = NotificationCompat.Builder(appContext, SUBSCRIPTION_NOTIFICATION_CHANNEL_ID)
+        val notification = NotificationCompat.Builder(
+            appContext,
+            SUBSCRIPTION_NOTIFICATION_CHANNEL_ID,
+        )
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(text)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .build()
-        notificationManager.notify(subscriptionId, notification)
+        notificationManager.notify(subscriptionId.hashCode(), notification)
     }
+}
+
+/**
+ * Returns the number of days until the next payment for [subscription] relative to [todayEpochDays],
+ * or null if the subscription has no notification config.
+ * A result of 0 means the payment is due today.
+ */
+internal fun daysUntilNextPayment(
+    subscription: Subscription,
+    todayEpochDays: Long,
+    calculator: PaymentInfoCalculator,
+): Int {
+    val paymentType = subscription.paymentInfo.type
+    val nextPayment = if (paymentType is PaymentType.Periodic) {
+        var candidate = subscription.paymentInfo.firstPayment
+        while (candidate.toEpochDays() < todayEpochDays) {
+            candidate = calculator.getNextDateByType(paymentType, candidate)
+        }
+        candidate
+    } else {
+        subscription.paymentInfo.firstPayment
+    }
+    return (nextPayment.toEpochDays() - todayEpochDays).toInt()
 }

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -89,7 +89,7 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
         val notificationManager = NotificationManagerCompat.from(appContext)
         if (!notificationManager.areNotificationsEnabled()) return
         val notification = NotificationCompat.Builder(appContext, SUBSCRIPTION_NOTIFICATION_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(text)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -79,8 +79,9 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
         val text = if (daysUntilPayment == 0) {
             appContext.getString(UiR.string.subscription_notification_text_today, subscriptionName)
         } else {
-            appContext.getString(
-                UiR.string.subscription_notification_text_days,
+            appContext.resources.getQuantityString(
+                UiR.plurals.subscription_notification_text_days,
+                daysUntilPayment,
                 subscriptionName,
                 daysUntilPayment,
             )

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -64,7 +64,7 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
             val days = daysUntilNextPayment(subscription, todayEpochDays, calculator) ?: return@forEach
             if (days == config.daysBeforePayment) {
                 sendNotification(
-                    subscriptionId = subscription.id.value.toInt(),
+                    subscriptionId = subscription.id.value.hashCode(),
                     subscriptionName = subscription.name,
                     daysUntilPayment = days,
                 )

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -54,7 +54,7 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
         val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return
         subscriptions.forEach { subscription ->
             val config = subscription.notificationConfig ?: return@forEach
-            val days = daysUntilNextPayment(subscription, todayEpochDays, calculator)
+            val days = daysUntilNextPayment(subscription, todayEpochDays, calculator) ?: return@forEach
             if (days == config.daysBeforePayment) {
                 sendNotification(
                     subscriptionId = subscription.id.value,
@@ -110,7 +110,8 @@ internal fun daysUntilNextPayment(
     subscription: Subscription,
     todayEpochDays: Long,
     calculator: PaymentInfoCalculator,
-): Int {
+): Int? {
+    subscription.notificationConfig ?: return null
     val paymentType = subscription.paymentInfo.type
     val nextPayment = if (paymentType is PaymentType.Periodic) {
         var candidate = subscription.paymentInfo.firstPayment

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -35,7 +35,11 @@ internal fun daysUntilNextPayment(
     subscription.notificationConfig ?: return null
     val paymentType = subscription.paymentInfo.type
     val nextPayment = if (paymentType is PaymentType.Periodic) {
-        calculator.getNextDateByType(paymentType)
+        var candidate = subscription.paymentInfo.firstPayment
+        while (candidate.toEpochDays() < todayEpochDays) {
+            candidate = calculator.getNextDateByType(paymentType, candidate)
+        }
+        candidate
     } else {
         subscription.paymentInfo.firstPayment
     }

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -1,7 +1,5 @@
 package dev.pott.abonity.app.notification
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -56,7 +54,6 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
-        ensureNotificationChannel()
         val todayEpochDays = clock.todayIn(TimeZone.currentSystemDefault()).toEpochDays()
         val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return Result.success()
         subscriptions.forEach { subscription ->
@@ -71,18 +68,6 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
             }
         }
         return Result.success()
-    }
-
-    private fun ensureNotificationChannel() {
-        val manager = appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (manager.getNotificationChannel(SUBSCRIPTION_NOTIFICATION_CHANNEL_ID) == null) {
-            val channel = NotificationChannel(
-                SUBSCRIPTION_NOTIFICATION_CHANNEL_ID,
-                appContext.getString(UiR.string.subscription_notification_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT,
-            )
-            manager.createNotificationChannel(channel)
-        }
     }
 
     private fun sendNotification(

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorker.kt
@@ -27,7 +27,7 @@ const val SUBSCRIPTION_NOTIFICATION_CHANNEL_ID = "subscription_payment_reminders
  */
 internal fun daysUntilNextPayment(
     subscription: dev.pott.abonity.core.entity.subscription.Subscription,
-    todayEpochDays: Int,
+    todayEpochDays: Long,
     calculator: PaymentInfoCalculator,
 ): Int? {
     subscription.notificationConfig ?: return null
@@ -54,7 +54,7 @@ class SubscriptionNotificationWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
-        val todayEpochDays = clock.todayIn(TimeZone.currentSystemDefault()).toEpochDays().toInt()
+        val todayEpochDays = clock.todayIn(TimeZone.currentSystemDefault()).toEpochDays()
         val subscriptions = repository.getSubscriptionsFlow().firstOrNull() ?: return Result.success()
         subscriptions.forEach { subscription ->
             val config = subscription.notificationConfig ?: return@forEach

--- a/app/src/main/kotlin/dev/pott/abonity/app/notification/WorkManagerSubscriptionNotificationScheduler.kt
+++ b/app/src/main/kotlin/dev/pott/abonity/app/notification/WorkManagerSubscriptionNotificationScheduler.kt
@@ -1,0 +1,25 @@
+package dev.pott.abonity.app.notification
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.pott.abonity.core.domain.subscription.SubscriptionNotificationScheduler
+import javax.inject.Inject
+
+internal const val SUBSCRIPTION_NOTIFICATION_IMMEDIATE_WORK_ID = "SUBSCRIPTION_NOTIFICATION_NOW"
+
+class WorkManagerSubscriptionNotificationScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : SubscriptionNotificationScheduler {
+
+    override fun scheduleImmediateCheck() {
+        val request = OneTimeWorkRequestBuilder<SubscriptionNotificationWorker>().build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            SUBSCRIPTION_NOTIFICATION_IMMEDIATE_WORK_ID,
+            ExistingWorkPolicy.REPLACE,
+            request,
+        )
+    }
+}

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
+</vector>

--- a/app/src/test/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorkerTest.kt
+++ b/app/src/test/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorkerTest.kt
@@ -12,6 +12,7 @@ import dev.pott.abonity.core.entity.subscription.PaymentPeriod
 import dev.pott.abonity.core.entity.subscription.PaymentType
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.todayIn
 import org.junit.jupiter.api.Test
@@ -81,13 +82,32 @@ class SubscriptionNotificationWorkerTest {
     }
 
     @Test
-    fun `GIVEN periodic subscription WHEN daysUntilNextPayment THEN uses next occurrence from today`() {
-        // calculator uses FakeClock internally; next payment = today + 1 month
-        val expectedNextPayment = today.plus(DatePeriod(months = 1))
-        val expectedDays = (expectedNextPayment.toEpochDays() - todayEpochDays).toInt()
+    fun `GIVEN periodic subscription with firstPayment today WHEN daysUntilNextPayment THEN returns 0`() {
+        // firstPayment == today, so the next upcoming occurrence is today itself
         val subscription = createTestSubscription(
             paymentInfo = createTestPaymentInfo(
                 firstPayment = today,
+                type = PaymentType.Periodic(1, PaymentPeriod.MONTHS),
+            ),
+            notificationConfig = NotificationConfig(daysBeforePayment = 0),
+        )
+
+        val result = daysUntilNextPayment(subscription, todayEpochDays, calculator)
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `GIVEN periodic subscription with firstPayment 5 days before today WHEN daysUntilNextPayment THEN returns days to next occurrence on subscription payment day`() {
+        // today = 2021-03-01, firstPayment = 2021-02-24 (5 days ago)
+        // iteration: Feb 24 < Mar 1 → advance to Mar 24
+        // next payment = Mar 24 = 23 days from today
+        val firstPayment = today.minus(DatePeriod(days = 5))
+        val expectedNextPayment = firstPayment.plus(DatePeriod(months = 1))
+        val expectedDays = (expectedNextPayment.toEpochDays() - todayEpochDays).toInt()
+        val subscription = createTestSubscription(
+            paymentInfo = createTestPaymentInfo(
+                firstPayment = firstPayment,
                 type = PaymentType.Periodic(1, PaymentPeriod.MONTHS),
             ),
             notificationConfig = NotificationConfig(daysBeforePayment = expectedDays),
@@ -96,5 +116,22 @@ class SubscriptionNotificationWorkerTest {
         val result = daysUntilNextPayment(subscription, todayEpochDays, calculator)
 
         assertThat(result).isEqualTo(expectedDays)
+    }
+
+    @Test
+    fun `GIVEN periodic subscription with firstPayment 5 days from now WHEN daysUntilNextPayment THEN returns 5`() {
+        // subscription hasn't started yet; next payment is the first payment itself
+        val firstPayment = today.plus(DatePeriod(days = 5))
+        val subscription = createTestSubscription(
+            paymentInfo = createTestPaymentInfo(
+                firstPayment = firstPayment,
+                type = PaymentType.Periodic(1, PaymentPeriod.MONTHS),
+            ),
+            notificationConfig = NotificationConfig(daysBeforePayment = 5),
+        )
+
+        val result = daysUntilNextPayment(subscription, todayEpochDays, calculator)
+
+        assertThat(result).isEqualTo(5)
     }
 }

--- a/app/src/test/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorkerTest.kt
+++ b/app/src/test/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorkerTest.kt
@@ -17,8 +17,6 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.todayIn
 import org.junit.jupiter.api.Test
 
-
-//TODO: Add proper worker tests
 class SubscriptionNotificationWorkerTest {
 
     private val clock = FakeClock()

--- a/app/src/test/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorkerTest.kt
+++ b/app/src/test/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorkerTest.kt
@@ -17,6 +17,8 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.todayIn
 import org.junit.jupiter.api.Test
 
+
+//TODO: Add proper worker tests
 class SubscriptionNotificationWorkerTest {
 
     private val clock = FakeClock()

--- a/app/src/test/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorkerTest.kt
+++ b/app/src/test/kotlin/dev/pott/abonity/app/notification/SubscriptionNotificationWorkerTest.kt
@@ -1,0 +1,100 @@
+package dev.pott.abonity.app.notification
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import dev.pott.abonity.core.domain.FakeClock
+import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
+import dev.pott.abonity.core.domain.subscription.entities.createTestPaymentInfo
+import dev.pott.abonity.core.domain.subscription.entities.createTestSubscription
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
+import dev.pott.abonity.core.entity.subscription.PaymentPeriod
+import dev.pott.abonity.core.entity.subscription.PaymentType
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.todayIn
+import org.junit.jupiter.api.Test
+
+class SubscriptionNotificationWorkerTest {
+
+    private val clock = FakeClock()
+    private val calculator = PaymentInfoCalculator(clock)
+    private val today = clock.todayIn(TimeZone.currentSystemDefault())
+    private val todayEpochDays = today.toEpochDays()
+
+    @Test
+    fun `GIVEN subscription without notificationConfig WHEN daysUntilNextPayment THEN returns null`() {
+        val subscription = createTestSubscription(notificationConfig = null)
+
+        val result = daysUntilNextPayment(subscription, todayEpochDays, calculator)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `GIVEN one-time subscription with payment today WHEN daysUntilNextPayment THEN returns 0`() {
+        val subscription = createTestSubscription(
+            paymentInfo = createTestPaymentInfo(
+                firstPayment = today,
+                type = PaymentType.OneTime,
+            ),
+            notificationConfig = NotificationConfig(daysBeforePayment = 0),
+        )
+
+        val result = daysUntilNextPayment(subscription, todayEpochDays, calculator)
+
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `GIVEN one-time subscription with payment in 7 days WHEN daysUntilNextPayment THEN returns 7`() {
+        val paymentDate = today.plus(DatePeriod(days = 7))
+        val subscription = createTestSubscription(
+            paymentInfo = createTestPaymentInfo(
+                firstPayment = paymentDate,
+                type = PaymentType.OneTime,
+            ),
+            notificationConfig = NotificationConfig(daysBeforePayment = 7),
+        )
+
+        val result = daysUntilNextPayment(subscription, todayEpochDays, calculator)
+
+        assertThat(result).isEqualTo(7)
+    }
+
+    @Test
+    fun `GIVEN one-time subscription where payment days don't match config WHEN daysUntilNextPayment THEN result differs from daysBeforePayment`() {
+        val paymentDate = today.plus(DatePeriod(days = 5))
+        val subscription = createTestSubscription(
+            paymentInfo = createTestPaymentInfo(
+                firstPayment = paymentDate,
+                type = PaymentType.OneTime,
+            ),
+            notificationConfig = NotificationConfig(daysBeforePayment = 3),
+        )
+
+        val days = daysUntilNextPayment(subscription, todayEpochDays, calculator)
+
+        assertThat(days).isEqualTo(5)
+        assertThat(days == subscription.notificationConfig!!.daysBeforePayment).isEqualTo(false)
+    }
+
+    @Test
+    fun `GIVEN periodic subscription WHEN daysUntilNextPayment THEN uses next occurrence from today`() {
+        // calculator uses FakeClock internally; next payment = today + 1 month
+        val expectedNextPayment = today.plus(DatePeriod(months = 1))
+        val expectedDays = (expectedNextPayment.toEpochDays() - todayEpochDays).toInt()
+        val subscription = createTestSubscription(
+            paymentInfo = createTestPaymentInfo(
+                firstPayment = today,
+                type = PaymentType.Periodic(1, PaymentPeriod.MONTHS),
+            ),
+            notificationConfig = NotificationConfig(daysBeforePayment = expectedDays),
+        )
+
+        val result = daysUntilNextPayment(subscription, todayEpochDays, calculator)
+
+        assertThat(result).isEqualTo(expectedDays)
+    }
+}

--- a/core/domain/src/main/kotlin/dev/pott/abonity/core/domain/subscription/SubscriptionNotificationScheduler.kt
+++ b/core/domain/src/main/kotlin/dev/pott/abonity/core/domain/subscription/SubscriptionNotificationScheduler.kt
@@ -1,0 +1,5 @@
+package dev.pott.abonity.core.domain.subscription
+
+interface SubscriptionNotificationScheduler {
+    fun scheduleImmediateCheck()
+}

--- a/core/domain/src/testFixtures/kotlin/dev/pott/abonity/core/domain/subscription/FakeSubscriptionNotificationScheduler.kt
+++ b/core/domain/src/testFixtures/kotlin/dev/pott/abonity/core/domain/subscription/FakeSubscriptionNotificationScheduler.kt
@@ -1,0 +1,10 @@
+package dev.pott.abonity.core.domain.subscription
+
+class FakeSubscriptionNotificationScheduler : SubscriptionNotificationScheduler {
+    var immediateCheckCount: Int = 0
+        private set
+
+    override fun scheduleImmediateCheck() {
+        immediateCheckCount++
+    }
+}

--- a/core/domain/src/testFixtures/kotlin/dev/pott/abonity/core/domain/subscription/entities/TestSubscriptionFactory.kt
+++ b/core/domain/src/testFixtures/kotlin/dev/pott/abonity/core/domain/subscription/entities/TestSubscriptionFactory.kt
@@ -2,6 +2,7 @@ package dev.pott.abonity.core.domain.subscription.entities
 
 import dev.pott.abonity.core.entity.subscription.Category
 import dev.pott.abonity.core.entity.subscription.CategoryId
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.PaymentInfo
 import dev.pott.abonity.core.entity.subscription.Subscription
 import dev.pott.abonity.core.entity.subscription.SubscriptionId
@@ -17,6 +18,7 @@ fun createTestSubscription(
     description: String = "Test Description",
     paymentInfo: PaymentInfo = createTestPaymentInfo(),
     categories: List<Category> = listOf(Category(CategoryId(1), "Test Category")),
+    notificationConfig: NotificationConfig? = null,
 ): Subscription =
     Subscription(
         SubscriptionId(id),
@@ -24,6 +26,7 @@ fun createTestSubscription(
         description,
         paymentInfo,
         categories,
+        notificationConfig,
     )
 
 fun createTestSubscriptionList(size: Int = 5): List<Subscription> {

--- a/core/entity/src/main/kotlin/dev/pott/abonity/core/entity/subscription/NotificationConfig.kt
+++ b/core/entity/src/main/kotlin/dev/pott/abonity/core/entity/subscription/NotificationConfig.kt
@@ -1,0 +1,5 @@
+package dev.pott.abonity.core.entity.subscription
+
+data class NotificationConfig(
+    val daysBeforePayment: Int,
+)

--- a/core/entity/src/main/kotlin/dev/pott/abonity/core/entity/subscription/NotificationConfig.kt
+++ b/core/entity/src/main/kotlin/dev/pott/abonity/core/entity/subscription/NotificationConfig.kt
@@ -1,5 +1,3 @@
 package dev.pott.abonity.core.entity.subscription
 
-data class NotificationConfig(
-    val daysBeforePayment: Int,
-)
+data class NotificationConfig(val daysBeforePayment: Int)

--- a/core/entity/src/main/kotlin/dev/pott/abonity/core/entity/subscription/Subscription.kt
+++ b/core/entity/src/main/kotlin/dev/pott/abonity/core/entity/subscription/Subscription.kt
@@ -6,4 +6,5 @@ data class Subscription(
     val description: String?,
     val paymentInfo: PaymentInfo,
     val categories: List<Category>,
+    val notificationConfig: NotificationConfig? = null,
 )

--- a/core/local/src/main/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabase.kt
+++ b/core/local/src/main/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabase.kt
@@ -2,12 +2,22 @@ package dev.pott.abonity.core.local.subscription.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import dev.pott.abonity.core.local.subscription.db.entities.CategoryEntity
 import dev.pott.abonity.core.local.subscription.db.entities.SubscriptionCategoryCrossRef
 import dev.pott.abonity.core.local.subscription.db.entities.SubscriptionEntity
 
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE subscription_entity ADD COLUMN notification_days_before INTEGER DEFAULT NULL",
+        )
+    }
+}
+
 @Database(
-    version = 1,
+    version = 2,
     entities = [
         SubscriptionEntity::class,
         CategoryEntity::class,

--- a/core/local/src/main/kotlin/dev/pott/abonity/core/local/subscription/db/entities/SubscriptionEntity.kt
+++ b/core/local/src/main/kotlin/dev/pott/abonity/core/local/subscription/db/entities/SubscriptionEntity.kt
@@ -34,6 +34,11 @@ data class SubscriptionEntity(
      */
     @ColumnInfo("period")
     val period: LocalPaymentPeriod?,
+    /**
+     * Days before payment to send a notification. Null means notifications are disabled.
+     */
+    @ColumnInfo("notification_days_before", defaultValue = "NULL")
+    val notificationDaysBefore: Int? = null,
 ) {
     init {
         if (paymentType == LocalPaymentType.PERIODICALLY) {

--- a/core/local/src/main/kotlin/dev/pott/abonity/core/local/subscription/mapper/SubscriptionMapper.kt
+++ b/core/local/src/main/kotlin/dev/pott/abonity/core/local/subscription/mapper/SubscriptionMapper.kt
@@ -1,5 +1,6 @@
 package dev.pott.abonity.core.local.subscription.mapper
 
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.PaymentInfo
 import dev.pott.abonity.core.entity.subscription.PaymentType
 import dev.pott.abonity.core.entity.subscription.Price
@@ -29,6 +30,7 @@ fun Subscription.toEntity(): SubscriptionCategoryEntity {
             paymentType.toEntity(),
             periodCount,
             period,
+            notificationConfig?.daysBeforePayment,
         ),
         categories = categories.map { it.toEntity() },
     )
@@ -57,6 +59,7 @@ private fun SubscriptionEntity.toDomain(categories: List<CategoryEntity>): Subsc
         name = name,
         description = description,
         paymentInfo = paymentInfo,
-        categories.map { it.toDomain() },
+        categories = categories.map { it.toDomain() },
+        notificationConfig = notificationDaysBefore?.let { NotificationConfig(it) },
     )
 }

--- a/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/RoomSubscriptionDataSourceTest.kt
+++ b/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/RoomSubscriptionDataSourceTest.kt
@@ -3,8 +3,10 @@ package dev.pott.abonity.core.local.subscription
 import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import dev.pott.abonity.core.domain.subscription.entities.createTestPaymentInfo
 import dev.pott.abonity.core.domain.subscription.entities.createTestSubscription
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.PaymentPeriod
 import dev.pott.abonity.core.entity.subscription.PaymentType
 import dev.pott.abonity.core.local.fakes.FakeSubscriptionDao
@@ -50,6 +52,73 @@ class RoomSubscriptionDataSourceTest {
             )
             dataSource.getSubscriptionsFlow().test {
                 assertThat(awaitItem()).isEqualTo(expected)
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN entity with notificationDaysBefore set WHEN getSubscriptionsFlow THEN domain has matching NotificationConfig`() {
+        runTest {
+            val entity = createTestSubscriptionCategoryEntityWithPeriodicPayment(
+                id = 1,
+                notificationDaysBefore = 3,
+            )
+            val dao = FakeSubscriptionDao(initialEntities = listOf(entity))
+            val dataSource = RoomSubscriptionDataSource(dao)
+
+            dataSource.getSubscriptionsFlow().test {
+                val subscription = awaitItem().first()
+                assertThat(subscription.notificationConfig)
+                    .isEqualTo(NotificationConfig(daysBeforePayment = 3))
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN entity with null notificationDaysBefore WHEN getSubscriptionsFlow THEN domain has null notificationConfig`() {
+        runTest {
+            val entity = createTestSubscriptionCategoryEntityWithPeriodicPayment(
+                id = 1,
+                notificationDaysBefore = null,
+            )
+            val dao = FakeSubscriptionDao(initialEntities = listOf(entity))
+            val dataSource = RoomSubscriptionDataSource(dao)
+
+            dataSource.getSubscriptionsFlow().test {
+                val subscription = awaitItem().first()
+                assertThat(subscription.notificationConfig).isNull()
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN subscription with NotificationConfig WHEN addOrUpdateSubscription THEN entity has correct notificationDaysBefore`() {
+        runTest {
+            val dao = FakeSubscriptionDao()
+            val dataSource = RoomSubscriptionDataSource(dao)
+            val subscription = createTestSubscription(
+                notificationConfig = NotificationConfig(daysBeforePayment = 7),
+            )
+
+            dataSource.addOrUpdateSubscription(subscription)
+
+            dao.getSubscriptionsFlow().test {
+                assertThat(awaitItem().first().subscription.notificationDaysBefore).isEqualTo(7)
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN subscription with null notificationConfig WHEN addOrUpdateSubscription THEN entity has null notificationDaysBefore`() {
+        runTest {
+            val dao = FakeSubscriptionDao()
+            val dataSource = RoomSubscriptionDataSource(dao)
+            val subscription = createTestSubscription(notificationConfig = null)
+
+            dataSource.addOrUpdateSubscription(subscription)
+
+            dao.getSubscriptionsFlow().test {
+                assertThat(awaitItem().first().subscription.notificationDaysBefore).isNull()
             }
         }
     }

--- a/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabaseMigrationTest.kt
+++ b/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabaseMigrationTest.kt
@@ -1,13 +1,13 @@
 package dev.pott.abonity.core.local.subscription.db
 
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
-import androidx.sqlite.db.SupportSQLiteDatabase
-import androidx.sqlite.db.SupportSQLiteOpenHelper
-import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabaseMigrationTest.kt
+++ b/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabaseMigrationTest.kt
@@ -6,7 +6,6 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
-import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -90,8 +89,13 @@ class AppDatabaseMigrationTest {
 
         openV2Database().use { db ->
             db.execSQL(
-                "INSERT INTO subscription_entity " +
-                    "(name, price, currency, first_payment_local_date, payment_type, notification_days_before) " +
+                "INSERT INTO subscription_entity (" +
+                    "name, " +
+                    "price, " +
+                    "currency, " +
+                    "first_payment_local_date, " +
+                    "payment_type, " +
+                    "notification_days_before) " +
                     "VALUES ('New Sub', 4.99, 'USD', '2024-01-01', 'ONE_TIME', NULL)",
             )
             val cursor = db.query(
@@ -110,8 +114,13 @@ class AppDatabaseMigrationTest {
 
         openV2Database().use { db ->
             db.execSQL(
-                "INSERT INTO subscription_entity " +
-                    "(name, price, currency, first_payment_local_date, payment_type, notification_days_before) " +
+                "INSERT INTO subscription_entity (" +
+                    "name, " +
+                    "price, " +
+                    "currency, " +
+                    "first_payment_local_date, " +
+                    "payment_type, " +
+                    "notification_days_before) " +
                     "VALUES ('Notified Sub', 9.99, 'EUR', '2024-06-01', 'ONE_TIME', 7)",
             )
             val cursor = db.query(
@@ -128,27 +137,50 @@ class AppDatabaseMigrationTest {
     private fun createV1DatabaseWithData() {
         val config = SupportSQLiteOpenHelper.Configuration.builder(context)
             .name(TEST_DB_NAME)
-            .callback(object : SupportSQLiteOpenHelper.Callback(1) {
-                override fun onCreate(db: SupportSQLiteDatabase) {
-                    db.execSQL(CREATE_SUBSCRIPTION_ENTITY_V1)
-                    db.execSQL(
-                        "INSERT INTO subscription_entity " +
-                            "(name, description, price, currency, first_payment_local_date, payment_type, period_count, period) " +
-                            "VALUES ('Periodic Sub', 'Monthly service', 9.99, 'EUR', '2020-02-02', 'PERIODICALLY', 1, 'MONTHS')",
-                    )
-                    db.execSQL(
-                        "INSERT INTO subscription_entity " +
-                            "(name, description, price, currency, first_payment_local_date, payment_type) " +
-                            "VALUES ('One Time Sub', 'One time purchase', 49.99, 'USD', '2021-05-15', 'ONE_TIME')",
-                    )
-                }
+            .callback(
+                object : SupportSQLiteOpenHelper.Callback(1) {
+                    override fun onCreate(db: SupportSQLiteDatabase) {
+                        db.execSQL(CREATE_SUBSCRIPTION_ENTITY_V1)
+                        db.execSQL(
+                            "INSERT INTO subscription_entity (" +
+                                "name, " +
+                                "description, " +
+                                "price, currency, " +
+                                "first_payment_local_date, " +
+                                "payment_type, period_count, " +
+                                "period) " +
+                                "VALUES (" +
+                                "'Periodic Sub', " +
+                                "'Monthly service', " +
+                                "9.99, 'EUR', " +
+                                "'2020-02-02', " +
+                                "'PERIODICALLY', " +
+                                "1, " +
+                                "'MONTHS')",
+                        )
+                        db.execSQL(
+                            "INSERT INTO subscription_entity (" +
+                                "name, " +
+                                "description, " +
+                                "price, currency, " +
+                                "first_payment_local_date, " +
+                                "payment_type) " +
+                                "VALUES (" +
+                                "'One Time Sub', " +
+                                "'One time purchase', " +
+                                "49.99, 'USD', " +
+                                "'2021-05-15', " +
+                                "'ONE_TIME')",
+                        )
+                    }
 
-                override fun onUpgrade(
-                    db: SupportSQLiteDatabase,
-                    oldVersion: Int,
-                    newVersion: Int,
-                ) = Unit
-            })
+                    override fun onUpgrade(
+                        db: SupportSQLiteDatabase,
+                        oldVersion: Int,
+                        newVersion: Int,
+                    ) = Unit
+                },
+            )
             .build()
         FrameworkSQLiteOpenHelperFactory().create(config).use { helper ->
             helper.writableDatabase.close()
@@ -158,19 +190,21 @@ class AppDatabaseMigrationTest {
     private fun openV2Database(): SupportSQLiteDatabase {
         val config = SupportSQLiteOpenHelper.Configuration.builder(context)
             .name(TEST_DB_NAME)
-            .callback(object : SupportSQLiteOpenHelper.Callback(2) {
-                override fun onCreate(db: SupportSQLiteDatabase) = Unit
+            .callback(
+                object : SupportSQLiteOpenHelper.Callback(2) {
+                    override fun onCreate(db: SupportSQLiteDatabase) = Unit
 
-                override fun onUpgrade(
-                    db: SupportSQLiteDatabase,
-                    oldVersion: Int,
-                    newVersion: Int,
-                ) {
-                    if (oldVersion < 2) {
-                        MIGRATION_1_2.migrate(db)
+                    override fun onUpgrade(
+                        db: SupportSQLiteDatabase,
+                        oldVersion: Int,
+                        newVersion: Int,
+                    ) {
+                        if (oldVersion < 2) {
+                            MIGRATION_1_2.migrate(db)
+                        }
                     }
-                }
-            })
+                },
+            )
             .build()
         return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
     }

--- a/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabaseMigrationTest.kt
+++ b/core/local/src/test/kotlin/dev/pott/abonity/core/local/subscription/db/AppDatabaseMigrationTest.kt
@@ -1,0 +1,191 @@
+package dev.pott.abonity.core.local.subscription.db
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+
+private const val TEST_DB_NAME = "app_database_migration_test.db"
+
+private const val CREATE_SUBSCRIPTION_ENTITY_V1 =
+    "CREATE TABLE IF NOT EXISTS subscription_entity " +
+        "(id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+        "name TEXT NOT NULL, " +
+        "description TEXT, " +
+        "price REAL NOT NULL, " +
+        "currency TEXT NOT NULL, " +
+        "first_payment_local_date TEXT NOT NULL, " +
+        "payment_type TEXT NOT NULL, " +
+        "period_count INTEGER, " +
+        "period TEXT)"
+
+@ExtendWith(RobolectricExtension::class)
+@Config(maxSdk = 34)
+class AppDatabaseMigrationTest {
+
+    private val context get() = RuntimeEnvironment.getApplication()
+
+    @BeforeEach
+    fun setUp() {
+        context.deleteDatabase(TEST_DB_NAME)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        context.deleteDatabase(TEST_DB_NAME)
+    }
+
+    @Test
+    fun `MIGRATION_1_2 adds notification_days_before column to subscription_entity`() {
+        createV1DatabaseWithData()
+
+        openV2Database().use { db ->
+            assertThat(hasColumn(db, "subscription_entity", "notification_days_before")).isTrue()
+        }
+    }
+
+    @Test
+    fun `MIGRATION_1_2 preserves existing rows after migration`() {
+        createV1DatabaseWithData()
+
+        openV2Database().use { db ->
+            val cursor = db.query(
+                "SELECT id, name, price FROM subscription_entity WHERE name = 'Periodic Sub'",
+            )
+            cursor.use {
+                assertThat(it.moveToFirst()).isTrue()
+            }
+        }
+    }
+
+    @Test
+    fun `MIGRATION_1_2 sets notification_days_before to null for pre-existing rows`() {
+        createV1DatabaseWithData()
+
+        openV2Database().use { db ->
+            val cursor = db.query(
+                "SELECT notification_days_before FROM subscription_entity WHERE name = 'Periodic Sub'",
+            )
+            cursor.use {
+                assertThat(it.moveToFirst()).isTrue()
+                assertThat(it.isNull(0)).isTrue()
+            }
+        }
+    }
+
+    @Test
+    fun `MIGRATION_1_2 notification_days_before column accepts null values after migration`() {
+        createV1DatabaseWithData()
+
+        openV2Database().use { db ->
+            db.execSQL(
+                "INSERT INTO subscription_entity " +
+                    "(name, price, currency, first_payment_local_date, payment_type, notification_days_before) " +
+                    "VALUES ('New Sub', 4.99, 'USD', '2024-01-01', 'ONE_TIME', NULL)",
+            )
+            val cursor = db.query(
+                "SELECT notification_days_before FROM subscription_entity WHERE name = 'New Sub'",
+            )
+            cursor.use {
+                assertThat(it.moveToFirst()).isTrue()
+                assertThat(it.isNull(0)).isTrue()
+            }
+        }
+    }
+
+    @Test
+    fun `MIGRATION_1_2 notification_days_before column accepts integer values after migration`() {
+        createV1DatabaseWithData()
+
+        openV2Database().use { db ->
+            db.execSQL(
+                "INSERT INTO subscription_entity " +
+                    "(name, price, currency, first_payment_local_date, payment_type, notification_days_before) " +
+                    "VALUES ('Notified Sub', 9.99, 'EUR', '2024-06-01', 'ONE_TIME', 7)",
+            )
+            val cursor = db.query(
+                "SELECT notification_days_before FROM subscription_entity WHERE name = 'Notified Sub'",
+            )
+            cursor.use {
+                assertThat(it.moveToFirst()).isTrue()
+                assertThat(it.isNull(0)).isFalse()
+                assertThat(it.getInt(0)).isEqualTo(7)
+            }
+        }
+    }
+
+    private fun createV1DatabaseWithData() {
+        val config = SupportSQLiteOpenHelper.Configuration.builder(context)
+            .name(TEST_DB_NAME)
+            .callback(object : SupportSQLiteOpenHelper.Callback(1) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(CREATE_SUBSCRIPTION_ENTITY_V1)
+                    db.execSQL(
+                        "INSERT INTO subscription_entity " +
+                            "(name, description, price, currency, first_payment_local_date, payment_type, period_count, period) " +
+                            "VALUES ('Periodic Sub', 'Monthly service', 9.99, 'EUR', '2020-02-02', 'PERIODICALLY', 1, 'MONTHS')",
+                    )
+                    db.execSQL(
+                        "INSERT INTO subscription_entity " +
+                            "(name, description, price, currency, first_payment_local_date, payment_type) " +
+                            "VALUES ('One Time Sub', 'One time purchase', 49.99, 'USD', '2021-05-15', 'ONE_TIME')",
+                    )
+                }
+
+                override fun onUpgrade(
+                    db: SupportSQLiteDatabase,
+                    oldVersion: Int,
+                    newVersion: Int,
+                ) = Unit
+            })
+            .build()
+        FrameworkSQLiteOpenHelperFactory().create(config).use { helper ->
+            helper.writableDatabase.close()
+        }
+    }
+
+    private fun openV2Database(): SupportSQLiteDatabase {
+        val config = SupportSQLiteOpenHelper.Configuration.builder(context)
+            .name(TEST_DB_NAME)
+            .callback(object : SupportSQLiteOpenHelper.Callback(2) {
+                override fun onCreate(db: SupportSQLiteDatabase) = Unit
+
+                override fun onUpgrade(
+                    db: SupportSQLiteDatabase,
+                    oldVersion: Int,
+                    newVersion: Int,
+                ) {
+                    if (oldVersion < 2) {
+                        MIGRATION_1_2.migrate(db)
+                    }
+                }
+            })
+            .build()
+        return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
+    }
+
+    private fun hasColumn(
+        db: SupportSQLiteDatabase,
+        tableName: String,
+        columnName: String,
+    ): Boolean {
+        db.query("PRAGMA table_info($tableName)").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            while (cursor.moveToNext()) {
+                if (cursor.getString(nameIndex) == columnName) return true
+            }
+        }
+        return false
+    }
+}

--- a/core/local/src/test/kotlin/dev/pott/abonity/core/local/testdata/TestSubscriptionEntityFactories.kt
+++ b/core/local/src/test/kotlin/dev/pott/abonity/core/local/testdata/TestSubscriptionEntityFactories.kt
@@ -16,6 +16,7 @@ fun createTestSubscriptionCategoryEntityWithPeriodicPayment(
     periodCount: Int = 1,
     period: LocalPaymentPeriod = LocalPaymentPeriod.MONTHS,
     categories: List<CategoryEntity> = listOf(CategoryEntity(1, "Test Category")),
+    notificationDaysBefore: Int? = null,
 ) = SubscriptionCategoryEntity(
     subscription = createSubscriptionEntityWithPeriodicPayment(
         id = id,
@@ -26,6 +27,7 @@ fun createTestSubscriptionCategoryEntityWithPeriodicPayment(
         firstPaymentLocalDate = firstPaymentLocalDate,
         periodCount = periodCount,
         period = period,
+        notificationDaysBefore = notificationDaysBefore,
     ),
     categories = categories,
 )
@@ -38,6 +40,7 @@ fun createTestSubscriptionCategoryEntityWithOneTimePayment(
     currency: String = "EUR",
     firstPaymentLocalDate: String = "2020-02-02",
     categories: List<CategoryEntity> = listOf(CategoryEntity(1, "Test Category")),
+    notificationDaysBefore: Int? = null,
 ) = SubscriptionCategoryEntity(
     subscription = createSubscriptionEntityWithOneTimePayment(
         id = id,
@@ -46,6 +49,7 @@ fun createTestSubscriptionCategoryEntityWithOneTimePayment(
         price = price,
         currency = currency,
         firstPaymentLocalDate = firstPaymentLocalDate,
+        notificationDaysBefore = notificationDaysBefore,
     ),
     categories = categories,
 )
@@ -59,6 +63,7 @@ fun createSubscriptionEntityWithPeriodicPayment(
     firstPaymentLocalDate: String = "2020-02-02",
     periodCount: Int = 1,
     period: LocalPaymentPeriod = LocalPaymentPeriod.MONTHS,
+    notificationDaysBefore: Int? = null,
 ) = SubscriptionEntity(
     id = id,
     name = name,
@@ -69,6 +74,7 @@ fun createSubscriptionEntityWithPeriodicPayment(
     paymentType = LocalPaymentType.PERIODICALLY,
     periodCount = periodCount,
     period = period,
+    notificationDaysBefore = notificationDaysBefore,
 )
 
 fun createSubscriptionEntityWithOneTimePayment(
@@ -78,6 +84,7 @@ fun createSubscriptionEntityWithOneTimePayment(
     price: Double = 9.99,
     currency: String = "EUR",
     firstPaymentLocalDate: String = "2020-02-02",
+    notificationDaysBefore: Int? = null,
 ) = SubscriptionEntity(
     id = id,
     name = name,
@@ -88,4 +95,5 @@ fun createSubscriptionEntityWithOneTimePayment(
     paymentType = LocalPaymentType.ONE_TIME,
     periodCount = null,
     period = null,
+    notificationDaysBefore = notificationDaysBefore,
 )

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -107,6 +107,20 @@
     <string name="subscription_add_label_period_dropdown_item_click">Periode</string>
     <string name="subscription_add_label_price">Preis</string>
     <string name="subscription_add_save">Einmalig</string>
+    <string name="subscription_detail_notification_label">Benachrichtigung setzen für: %s</string>
+    <string name="subscription_notification_dialog_title">Erinnere mich</string>
+    <string name="subscription_notification_dialog_off">Aus</string>
+    <string name="subscription_notification_dialog_period_days">Tage</string>
+    <string name="subscription_notification_dialog_period_weeks">Wochen</string>
+    <string name="subscription_notification_dialog_period_months">Monate</string>
+    <string name="subscription_notification_dialog_before_payment">vor der Zahlung</string>
+    <string name="subscription_notification_channel_name">Zahlungserinnerungen</string>
+    <string name="subscription_notification_title">Bevorstehende Zahlung: %s</string>
+    <string name="subscription_notification_text_today">%s ist heute fällig</string>
+    <plurals name="subscription_notification_text_days">
+        <item quantity="one">%s ist in %d Tag fällig</item>
+        <item quantity="other">%s ist in %d Tagen fällig</item>
+    </plurals>
     <string name="subscription_detail_delete_label">Zahlung löschen: %s</string>
     <string name="subscription_detail_description_label">Beschreibung</string>
     <string name="subscription_detail_edit_label">Zahlung bearbeiten: %s</string>

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -111,10 +111,10 @@
     <string name="subscription_notification_dialog_title">Erinnere mich</string>
     <string name="subscription_notification_dialog_off">Aus</string>
     <string name="subscription_notification_dialog_same_day">Am selben Tag</string>
-    <string name="subscription_notification_dialog_period_days">Tage</string>
-    <string name="subscription_notification_dialog_period_weeks">Wochen</string>
-    <string name="subscription_notification_dialog_period_months">Monate</string>
-    <string name="subscription_notification_dialog_before_payment">vor der Zahlung</string>
+    <plurals name="subscription_notification_dialog_days_before_payment">
+        <item quantity="one">Tag vor der Zahlung</item>
+        <item quantity="other">Tage vor der Zahlung</item>
+    </plurals>
     <string name="subscription_notification_channel_name">Zahlungserinnerungen</string>
     <string name="subscription_notification_title">Bevorstehende Zahlung: %s</string>
     <string name="subscription_notification_text_today">%s ist heute fällig</string>

--- a/core/ui/src/main/res/values-de/strings.xml
+++ b/core/ui/src/main/res/values-de/strings.xml
@@ -110,6 +110,7 @@
     <string name="subscription_detail_notification_label">Benachrichtigung setzen für: %s</string>
     <string name="subscription_notification_dialog_title">Erinnere mich</string>
     <string name="subscription_notification_dialog_off">Aus</string>
+    <string name="subscription_notification_dialog_same_day">Am selben Tag</string>
     <string name="subscription_notification_dialog_period_days">Tage</string>
     <string name="subscription_notification_dialog_period_weeks">Wochen</string>
     <string name="subscription_notification_dialog_period_months">Monate</string>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -121,6 +121,7 @@
     <string name="subscription_detail_notification_label">Définir une notification pour: %s</string>
     <string name="subscription_notification_dialog_title">Me notifier</string>
     <string name="subscription_notification_dialog_off">Désactivé</string>
+    <string name="subscription_notification_dialog_same_day">Le jour même</string>
     <string name="subscription_notification_dialog_period_days">Jours</string>
     <string name="subscription_notification_dialog_period_weeks">Semaines</string>
     <string name="subscription_notification_dialog_period_months">Mois</string>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -118,6 +118,21 @@
     <string name="subscription_add_label_period_dropdown_item_click">Période</string>
     <string name="subscription_add_label_price">Prix</string>
     <string name="subscription_add_save">Une fois</string>
+    <string name="subscription_detail_notification_label">Définir une notification pour: %s</string>
+    <string name="subscription_notification_dialog_title">Me notifier</string>
+    <string name="subscription_notification_dialog_off">Désactivé</string>
+    <string name="subscription_notification_dialog_period_days">Jours</string>
+    <string name="subscription_notification_dialog_period_weeks">Semaines</string>
+    <string name="subscription_notification_dialog_period_months">Mois</string>
+    <string name="subscription_notification_dialog_before_payment">avant le paiement</string>
+    <string name="subscription_notification_channel_name">Rappels de paiement</string>
+    <string name="subscription_notification_title">Paiement à venir: %s</string>
+    <string name="subscription_notification_text_today">%s est dû aujourd\'hui</string>
+    <plurals name="subscription_notification_text_days">
+        <item quantity="one">%s est dû dans %d jour</item>
+        <item quantity="other">%s est dû dans %d jours</item>
+        <item quantity="many">%s est dû dans %d jours</item>
+    </plurals>
     <string name="subscription_detail_delete_label">Supprimer le paiement: %s</string>
     <string name="subscription_detail_description_label">Description</string>
     <string name="subscription_detail_edit_label">Modifier le paiement: %s</string>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -122,10 +122,10 @@
     <string name="subscription_notification_dialog_title">Me notifier</string>
     <string name="subscription_notification_dialog_off">Désactivé</string>
     <string name="subscription_notification_dialog_same_day">Le jour même</string>
-    <string name="subscription_notification_dialog_period_days">Jours</string>
-    <string name="subscription_notification_dialog_period_weeks">Semaines</string>
-    <string name="subscription_notification_dialog_period_months">Mois</string>
-    <string name="subscription_notification_dialog_before_payment">avant le paiement</string>
+    <plurals name="subscription_notification_dialog_days_before_payment">
+        <item quantity="one" tools:ignore="ImpliedQuantity">jour avant le paiement</item>
+        <item quantity="other">jours avant le paiement</item>
+    </plurals>
     <string name="subscription_notification_channel_name">Rappels de paiement</string>
     <string name="subscription_notification_title">Paiement à venir: %s</string>
     <string name="subscription_notification_text_today">%s est dû aujourd\'hui</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -153,6 +153,17 @@
     <string name="subscription_filter_current_period_month">This month</string>
     <string name="subscription_filter_current_period_week">This week</string>
     <string name="subscription_filter_current_period_day">Today</string>
+    <string name="subscription_detail_notification_label">Set notification for: %s</string>
+    <string name="subscription_notification_dialog_title">Notify me</string>
+    <string name="subscription_notification_dialog_off">Off</string>
+    <string name="subscription_notification_dialog_same_day">On payment day</string>
+    <string name="subscription_notification_dialog_days_before">%d days before</string>
+    <string name="subscription_notification_dialog_one_day_before">1 day before</string>
+    <string name="subscription_notification_dialog_one_week_before">1 week before</string>
+    <string name="subscription_notification_channel_name">Payment Reminders</string>
+    <string name="subscription_notification_title">Upcoming payment: %s</string>
+    <string name="subscription_notification_text_today">%s is due today</string>
+    <string name="subscription_notification_text_days">%s is due in %d day(s)</string>
     <string name="payments_widget_description">Upcoming payments</string>
     <string name="payments_widget_no_upcoming_text">No upcoming payments! ❤️</string>
     <string name="payments_widget_preview_date">1.1.2022</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="subscription_detail_notification_label">Set notification for: %s</string>
     <string name="subscription_notification_dialog_title">Notify me</string>
     <string name="subscription_notification_dialog_off">Off</string>
+    <string name="subscription_notification_dialog_same_day">On the same day</string>
     <string name="subscription_notification_dialog_period_days">Days</string>
     <string name="subscription_notification_dialog_period_weeks">Weeks</string>
     <string name="subscription_notification_dialog_period_months">Months</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -156,13 +156,10 @@
     <string name="subscription_detail_notification_label">Set notification for: %s</string>
     <string name="subscription_notification_dialog_title">Notify me</string>
     <string name="subscription_notification_dialog_off">Off</string>
-    <string name="subscription_notification_dialog_same_day">On payment day</string>
-    <plurals name="subscription_notification_dialog_days_before">
-        <item quantity="one">%d day before</item>
-        <item quantity="other">%d days before</item>
-    </plurals>
-    <string name="subscription_notification_dialog_one_day_before">1 day before</string>
-    <string name="subscription_notification_dialog_one_week_before">1 week before</string>
+    <string name="subscription_notification_dialog_period_days">Days</string>
+    <string name="subscription_notification_dialog_period_weeks">Weeks</string>
+    <string name="subscription_notification_dialog_period_months">Months</string>
+    <string name="subscription_notification_dialog_before_payment">before payment</string>
     <string name="subscription_notification_channel_name">Payment Reminders</string>
     <string name="subscription_notification_title">Upcoming payment: %s</string>
     <string name="subscription_notification_text_today">%s is due today</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -157,7 +157,10 @@
     <string name="subscription_notification_dialog_title">Notify me</string>
     <string name="subscription_notification_dialog_off">Off</string>
     <string name="subscription_notification_dialog_same_day">On payment day</string>
-    <string name="subscription_notification_dialog_days_before">%d days before</string>
+    <plurals name="subscription_notification_dialog_days_before">
+        <item quantity="one">%d day before</item>
+        <item quantity="other">%d days before</item>
+    </plurals>
     <string name="subscription_notification_dialog_one_day_before">1 day before</string>
     <string name="subscription_notification_dialog_one_week_before">1 week before</string>
     <string name="subscription_notification_channel_name">Payment Reminders</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -157,10 +157,10 @@
     <string name="subscription_notification_dialog_title">Notify me</string>
     <string name="subscription_notification_dialog_off">Off</string>
     <string name="subscription_notification_dialog_same_day">On the same day</string>
-    <string name="subscription_notification_dialog_period_days">Days</string>
-    <string name="subscription_notification_dialog_period_weeks">Weeks</string>
-    <string name="subscription_notification_dialog_period_months">Months</string>
-    <string name="subscription_notification_dialog_before_payment">before payment</string>
+    <plurals name="subscription_notification_dialog_days_before_payment">
+        <item quantity="one">day before payment</item>
+        <item quantity="other">days before payment</item>
+    </plurals>
     <string name="subscription_notification_channel_name">Payment Reminders</string>
     <string name="subscription_notification_title">Upcoming payment: %s</string>
     <string name="subscription_notification_text_today">%s is due today</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -163,7 +163,10 @@
     <string name="subscription_notification_channel_name">Payment Reminders</string>
     <string name="subscription_notification_title">Upcoming payment: %s</string>
     <string name="subscription_notification_text_today">%s is due today</string>
-    <string name="subscription_notification_text_days">%s is due in %d day(s)</string>
+    <plurals name="subscription_notification_text_days">
+        <item quantity="one">%s is due in %d day</item>
+        <item quantity="other">%s is due in %d days</item>
+    </plurals>
     <string name="payments_widget_description">Upcoming payments</string>
     <string name="payments_widget_no_upcoming_text">No upcoming payments! ❤️</string>
     <string name="payments_widget_preview_date">1.1.2022</string>

--- a/database-schemas/dev.pott.abonity.core.local.subscription.db.AppDatabase/2.json
+++ b/database-schemas/dev.pott.abonity.core.local.subscription.db.AppDatabase/2.json
@@ -1,0 +1,177 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "e319d470f8840be8ea1f7b428529df63",
+    "entities": [
+      {
+        "tableName": "subscription_entity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `price` REAL NOT NULL, `currency` TEXT NOT NULL, `first_payment_local_date` TEXT NOT NULL, `payment_type` TEXT NOT NULL, `period_count` INTEGER, `period` TEXT, `notification_days_before` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPaymentLocalDate",
+            "columnName": "first_payment_local_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentType",
+            "columnName": "payment_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "periodCount",
+            "columnName": "period_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "period",
+            "columnName": "period",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notificationDaysBefore",
+            "columnName": "notification_days_before",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "category_entity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_category_entity_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_category_entity_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_category_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`subscription_id` INTEGER NOT NULL, `category_id` INTEGER NOT NULL, PRIMARY KEY(`subscription_id`, `category_id`), FOREIGN KEY(`subscription_id`) REFERENCES `subscription_entity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`category_id`) REFERENCES `category_entity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "subscription_id",
+            "category_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscription_category_cross_ref_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subscription_category_cross_ref_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "subscription_entity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "subscription_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "category_entity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e319d470f8840be8ea1f7b428529df63')"
+    ]
+  }
+}

--- a/feature/subscription/build.gradle.kts
+++ b/feature/subscription/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
     implementation(libs.kotlinx.serialization.json)
 
+    implementation(libs.accompanist.permission)
     implementation(libs.kermit)
 
     testImplementation(testFixtures(projects.core.domain))

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/DetailScreen.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/DetailScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -81,7 +80,7 @@ fun DetailScreen(
     val subscription = state.subscription
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     var showDeleteDialog by rememberSaveable { mutableStateOf(false) }
-    var showNotificationDialog by remember { mutableStateOf(false) }
+    var showNotificationDialog by rememberSaveable { mutableStateOf(false) }
     Scaffold(
         topBar = {
             TopAppBar(

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/DetailScreen.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/DetailScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +43,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dev.pott.abonity.core.entity.subscription.Category
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.PaymentInfo
 import dev.pott.abonity.core.entity.subscription.PaymentPeriod
 import dev.pott.abonity.core.entity.subscription.PaymentType
@@ -59,6 +61,7 @@ import dev.pott.abonity.core.ui.components.subscription.categories.Categories
 import dev.pott.abonity.core.ui.preview.PreviewCommonScreenConfig
 import dev.pott.abonity.core.ui.theme.AppIcons
 import dev.pott.abonity.core.ui.theme.AppTheme
+import dev.pott.abonity.feature.subscription.detail.components.NotificationConfigDialog
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -72,11 +75,13 @@ fun DetailScreen(
     close: () -> Unit,
     onEditClick: (SubscriptionId) -> Unit,
     onDeleteClick: (SubscriptionId) -> Unit,
+    onNotificationConfigChanged: (NotificationConfig?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val subscription = state.subscription
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-    var showDeleteDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by rememberSaveable { mutableStateOf(false) }
+    var showNotificationDialog by remember { mutableStateOf(false) }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -94,6 +99,7 @@ fun DetailScreen(
                         subscription = subscription,
                         onEditClick = onEditClick,
                         onDeleteClick = { showDeleteDialog = true },
+                        onNotificationClick = { showNotificationDialog = true },
                     )
                 },
                 scrollBehavior = scrollBehavior,
@@ -117,6 +123,16 @@ fun DetailScreen(
                             onDismiss = { showDeleteDialog = false },
                         )
                     }
+                    if (showNotificationDialog) {
+                        NotificationConfigDialog(
+                            currentConfig = subscription.notificationConfig,
+                            onConfirm = { config ->
+                                onNotificationConfigChanged(config)
+                                showNotificationDialog = false
+                            },
+                            onDismiss = { showNotificationDialog = false },
+                        )
+                    }
                     DetailLoadedContent(
                         it,
                         state,
@@ -133,6 +149,7 @@ private fun DetailActions(
     subscription: Subscription?,
     onEditClick: (SubscriptionId) -> Unit,
     onDeleteClick: (SubscriptionId) -> Unit,
+    onNotificationClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -143,6 +160,15 @@ private fun DetailActions(
     ) {
         Row {
             subscription?.let {
+                IconButton(onClick = onNotificationClick) {
+                    Icon(
+                        painter = rememberVectorPainter(image = AppIcons.Notification),
+                        contentDescription = stringResource(
+                            id = R.string.subscription_detail_notification_label,
+                            subscription.name,
+                        ),
+                    )
+                }
                 IconButton(onClick = { onEditClick(subscription.id) }) {
                     Icon(
                         painter = rememberVectorPainter(image = AppIcons.Edit),
@@ -386,6 +412,9 @@ private fun DetailScreenPreview() {
             },
             onDeleteClick = {
                 // Delete
+            },
+            onNotificationConfigChanged = {
+                // Update notification config
             },
         )
     }

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/DetailViewModel.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/DetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
 import dev.pott.abonity.core.domain.subscription.SubscriptionRepository
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.PaymentType
 import dev.pott.abonity.core.entity.subscription.SubscriptionId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -50,5 +52,12 @@ class DetailViewModel @Inject constructor(
 
     fun setId(detailId: SubscriptionId?) {
         currentDetailId.value = detailId
+    }
+
+    fun setNotificationConfig(config: NotificationConfig?) {
+        val subscription = state.value.subscription ?: return
+        viewModelScope.launch {
+            repository.addOrUpdateSubscription(subscription.copy(notificationConfig = config))
+        }
     }
 }

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/DetailViewModel.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/DetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
+import dev.pott.abonity.core.domain.subscription.SubscriptionNotificationScheduler
 import dev.pott.abonity.core.domain.subscription.SubscriptionRepository
 import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.PaymentType
@@ -22,6 +23,7 @@ import javax.inject.Inject
 class DetailViewModel @Inject constructor(
     private val repository: SubscriptionRepository,
     private val calculator: PaymentInfoCalculator,
+    private val notificationScheduler: SubscriptionNotificationScheduler,
 ) : ViewModel() {
 
     private val currentDetailId: MutableStateFlow<SubscriptionId?> = MutableStateFlow(null)
@@ -58,6 +60,9 @@ class DetailViewModel @Inject constructor(
         val subscription = state.value.subscription ?: return
         viewModelScope.launch {
             repository.addOrUpdateSubscription(subscription.copy(notificationConfig = config))
+            if (config != null) {
+                notificationScheduler.scheduleImmediateCheck()
+            }
         }
     }
 }

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -50,6 +50,9 @@ private enum class NotificationPeriod {
     MONTHS,
 }
 
+private const val DAYS_IN_WEEK = 7
+private const val APPROX_DAYS_IN_MONTH = 30
+
 private fun NotificationPeriod.labelRes(): Int = when (this) {
     NotificationPeriod.DAYS -> R.string.subscription_notification_dialog_period_days
     NotificationPeriod.WEEKS -> R.string.subscription_notification_dialog_period_weeks
@@ -59,10 +62,10 @@ private fun NotificationPeriod.labelRes(): Int = when (this) {
 private fun initialPeriodAndCount(daysBeforePayment: Int?): Pair<NotificationPeriod, Int> =
     when {
         daysBeforePayment == null -> Pair(NotificationPeriod.DAYS, 1)
-        daysBeforePayment % 30 == 0 && daysBeforePayment >= 30 ->
-            Pair(NotificationPeriod.MONTHS, daysBeforePayment / 30)
-        daysBeforePayment % 7 == 0 && daysBeforePayment >= 7 ->
-            Pair(NotificationPeriod.WEEKS, daysBeforePayment / 7)
+        daysBeforePayment % APPROX_DAYS_IN_MONTH == 0 && daysBeforePayment >= APPROX_DAYS_IN_MONTH ->
+            Pair(NotificationPeriod.MONTHS, daysBeforePayment / APPROX_DAYS_IN_MONTH)
+        daysBeforePayment % DAYS_IN_WEEK == 0 && daysBeforePayment >= DAYS_IN_WEEK ->
+            Pair(NotificationPeriod.WEEKS, daysBeforePayment / DAYS_IN_WEEK)
         else -> Pair(NotificationPeriod.DAYS, daysBeforePayment)
     }
 
@@ -227,8 +230,8 @@ fun NotificationConfigDialog(
                         val count = countText.toIntOrNull()?.coerceAtLeast(0) ?: 1
                         val days = when (period) {
                             NotificationPeriod.DAYS -> count
-                            NotificationPeriod.WEEKS -> count * 7
-                            NotificationPeriod.MONTHS -> count * 30
+                            NotificationPeriod.WEEKS -> count * DAYS_IN_WEEK
+                            NotificationPeriod.MONTHS -> count * APPROX_DAYS_IN_MONTH
                         }
                         requestPermissionAndConfirm(NotificationConfig(daysBeforePayment = days))
                     }

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -1,5 +1,7 @@
 package dev.pott.abonity.feature.subscription.detail.components
 
+import android.Manifest
+import android.os.Build
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -21,18 +23,39 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.ui.R
 import dev.pott.abonity.core.ui.theme.AppIcons
 
 private val NOTIFICATION_OPTIONS = listOf(null, 0, 1, 2, 3, 7)
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun NotificationConfigDialog(
     currentConfig: NotificationConfig?,
     onConfirm: (NotificationConfig?) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val notificationPermissionState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS)
+    } else {
+        null
+    }
+
+    val onOptionSelected = { days: Int? ->
+        val config = days?.let { NotificationConfig(it) }
+        if (config != null &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            notificationPermissionState?.status?.isGranted == false
+        ) {
+            notificationPermissionState.launchPermissionRequest()
+        }
+        onConfirm(config)
+    }
+
     AlertDialog(
         icon = {
             Icon(
@@ -63,12 +86,12 @@ fun NotificationConfigDialog(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onConfirm(days?.let { NotificationConfig(it) }) }
+                            .clickable { onOptionSelected(days) }
                             .padding(vertical = 4.dp),
                     ) {
                         RadioButton(
                             selected = isSelected,
-                            onClick = { onConfirm(days?.let { NotificationConfig(it) }) },
+                            onClick = { onOptionSelected(days) },
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -1,7 +1,9 @@
 package dev.pott.abonity.feature.subscription.detail.components
 
 import android.Manifest
+import android.content.Intent
 import android.os.Build
+import android.provider.Settings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,18 +12,30 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
@@ -30,30 +44,76 @@ import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.ui.R
 import dev.pott.abonity.core.ui.theme.AppIcons
 
-private val NOTIFICATION_OPTIONS = listOf(null, 0, 1, 2, 3, 7)
+private enum class NotificationPeriod {
+    DAYS,
+    WEEKS,
+    MONTHS,
+}
 
-@OptIn(ExperimentalPermissionsApi::class)
+private fun initialPeriodAndCount(daysBeforePayment: Int?): Pair<NotificationPeriod, Int> =
+    when {
+        daysBeforePayment == null -> Pair(NotificationPeriod.DAYS, 1)
+        daysBeforePayment % 30 == 0 && daysBeforePayment >= 30 ->
+            Pair(NotificationPeriod.MONTHS, daysBeforePayment / 30)
+        daysBeforePayment % 7 == 0 && daysBeforePayment >= 7 ->
+            Pair(NotificationPeriod.WEEKS, daysBeforePayment / 7)
+        else -> Pair(NotificationPeriod.DAYS, daysBeforePayment)
+    }
+
+@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationConfigDialog(
     currentConfig: NotificationConfig?,
     onConfirm: (NotificationConfig?) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val context = LocalContext.current
+    var showPermissionDeclinedDialog by remember { mutableStateOf(false) }
+    var pendingConfig by remember { mutableStateOf<NotificationConfig?>(null) }
+    var isWaitingForPermission by remember { mutableStateOf(false) }
+
     val notificationPermissionState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS)
+        rememberPermissionState(
+            permission = Manifest.permission.POST_NOTIFICATIONS,
+            onPermissionResult = { isGranted ->
+                if (isWaitingForPermission) {
+                    isWaitingForPermission = false
+                    onConfirm(pendingConfig)
+                    if (!isGranted) {
+                        showPermissionDeclinedDialog = true
+                    }
+                }
+            },
+        )
     } else {
         null
     }
 
-    val onOptionSelected = { days: Int? ->
-        val config = days?.let { NotificationConfig(it) }
+    val requestPermissionAndConfirm: (NotificationConfig?) -> Unit = { config ->
         if (config != null &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             notificationPermissionState?.status?.isGranted == false
         ) {
+            pendingConfig = config
+            isWaitingForPermission = true
             notificationPermissionState.launchPermissionRequest()
+        } else {
+            onConfirm(config)
         }
-        onConfirm(config)
+    }
+
+    val (initialPeriod, initialCount) = remember(currentConfig) {
+        initialPeriodAndCount(currentConfig?.daysBeforePayment)
+    }
+    var isOff by remember { mutableStateOf(currentConfig == null) }
+    var countText by remember { mutableStateOf(initialCount.toString()) }
+    var period by remember { mutableStateOf(initialPeriod) }
+    var periodExpanded by remember { mutableStateOf(false) }
+
+    val periodLabel = when (period) {
+        NotificationPeriod.DAYS -> stringResource(id = R.string.subscription_notification_dialog_period_days)
+        NotificationPeriod.WEEKS -> stringResource(id = R.string.subscription_notification_dialog_period_weeks)
+        NotificationPeriod.MONTHS -> stringResource(id = R.string.subscription_notification_dialog_period_months)
     }
 
     AlertDialog(
@@ -69,40 +129,166 @@ fun NotificationConfigDialog(
         text = {
             Column {
                 Spacer(modifier = Modifier.height(4.dp))
-                NOTIFICATION_OPTIONS.forEach { days ->
-                    val label = when (days) {
-                        null -> stringResource(id = R.string.subscription_notification_dialog_off)
-                        0 -> stringResource(id = R.string.subscription_notification_dialog_same_day)
-                        1 -> stringResource(id = R.string.subscription_notification_dialog_one_day_before)
-                        7 -> stringResource(id = R.string.subscription_notification_dialog_one_week_before)
-                        else -> pluralStringResource(
-                            id = R.plurals.subscription_notification_dialog_days_before,
-                            count = days,
-                            days,
-                        )
-                    }
-                    val isSelected = currentConfig?.daysBeforePayment == days
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onOptionSelected(days) }
-                            .padding(vertical = 4.dp),
-                    ) {
-                        RadioButton(
-                            selected = isSelected,
-                            onClick = { onOptionSelected(days) },
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { isOff = true }
+                        .padding(vertical = 4.dp),
+                ) {
+                    RadioButton(selected = isOff, onClick = { isOff = true })
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(id = R.string.subscription_notification_dialog_off),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                ) {
+                    RadioButton(selected = !isOff, onClick = { isOff = false })
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Column {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            OutlinedTextField(
+                                value = countText,
+                                onValueChange = { input ->
+                                    if (input.all { it.isDigit() }) {
+                                        countText = input
+                                        isOff = false
+                                    }
+                                },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                modifier = Modifier.weight(1f),
+                                singleLine = true,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            ExposedDropdownMenuBox(
+                                expanded = periodExpanded,
+                                onExpandedChange = { periodExpanded = it },
+                            ) {
+                                OutlinedTextField(
+                                    value = periodLabel,
+                                    onValueChange = {},
+                                    readOnly = true,
+                                    trailingIcon = {
+                                        ExposedDropdownMenuDefaults.TrailingIcon(
+                                            expanded = periodExpanded,
+                                        )
+                                    },
+                                    modifier = Modifier.menuAnchor(
+                                        ExposedDropdownMenuAnchorType.PrimaryNotEditable,
+                                    ),
+                                    singleLine = true,
+                                )
+                                ExposedDropdownMenu(
+                                    expanded = periodExpanded,
+                                    onDismissRequest = { periodExpanded = false },
+                                ) {
+                                    NotificationPeriod.entries.forEach { p ->
+                                        val label = when (p) {
+                                            NotificationPeriod.DAYS -> stringResource(
+                                                id = R.string.subscription_notification_dialog_period_days,
+                                            )
+                                            NotificationPeriod.WEEKS -> stringResource(
+                                                id = R.string.subscription_notification_dialog_period_weeks,
+                                            )
+                                            NotificationPeriod.MONTHS -> stringResource(
+                                                id = R.string.subscription_notification_dialog_period_months,
+                                            )
+                                        }
+                                        DropdownMenuItem(
+                                            text = { Text(text = label) },
+                                            onClick = {
+                                                period = p
+                                                periodExpanded = false
+                                                isOff = false
+                                            },
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
                         Text(
-                            text = label,
-                            style = MaterialTheme.typography.bodyMedium,
+                            text = stringResource(
+                                id = R.string.subscription_notification_dialog_before_payment,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
             }
         },
-        confirmButton = {},
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (isOff) {
+                        requestPermissionAndConfirm(null)
+                    } else {
+                        val count = countText.toIntOrNull()?.coerceAtLeast(0) ?: 1
+                        val days = when (period) {
+                            NotificationPeriod.DAYS -> count
+                            NotificationPeriod.WEEKS -> count * 7
+                            NotificationPeriod.MONTHS -> count * 30
+                        }
+                        requestPermissionAndConfirm(NotificationConfig(daysBeforePayment = days))
+                    }
+                },
+            ) {
+                Text(stringResource(id = R.string.dialog_btn_confirm_default))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(id = R.string.dialog_btn_dismiss_default))
+            }
+        },
+        onDismissRequest = onDismiss,
+    )
+
+    if (showPermissionDeclinedDialog) {
+        NotificationPermissionDeclinedDialog(
+            onDismiss = { showPermissionDeclinedDialog = false },
+            onOpenSettings = {
+                showPermissionDeclinedDialog = false
+                val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                }
+                context.startActivity(intent)
+            },
+        )
+    }
+}
+
+@Composable
+private fun NotificationPermissionDeclinedDialog(
+    onDismiss: () -> Unit,
+    onOpenSettings: () -> Unit,
+) {
+    AlertDialog(
+        icon = {
+            Icon(
+                painter = rememberVectorPainter(image = AppIcons.Notification),
+                contentDescription = null,
+            )
+        },
+        title = {
+            Text(text = stringResource(id = R.string.notification_permission_dialog_title))
+        },
+        text = {
+            Text(text = stringResource(id = R.string.notification_permission_dialog_text))
+        },
+        confirmButton = {
+            TextButton(onClick = onOpenSettings) {
+                Text(stringResource(id = R.string.notification_permission_dialog_settings_btn))
+            }
+        },
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(id = R.string.dialog_btn_dismiss_default))

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import dev.pott.abonity.core.entity.subscription.NotificationConfig
@@ -51,8 +52,9 @@ fun NotificationConfigDialog(
                         0 -> stringResource(id = R.string.subscription_notification_dialog_same_day)
                         1 -> stringResource(id = R.string.subscription_notification_dialog_one_day_before)
                         7 -> stringResource(id = R.string.subscription_notification_dialog_one_week_before)
-                        else -> stringResource(
-                            id = R.string.subscription_notification_dialog_days_before,
+                        else -> pluralStringResource(
+                            id = R.plurals.subscription_notification_dialog_days_before,
+                            count = days,
                             days,
                         )
                     }

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -50,6 +50,12 @@ private enum class NotificationPeriod {
     MONTHS,
 }
 
+private fun NotificationPeriod.labelRes(): Int = when (this) {
+    NotificationPeriod.DAYS -> R.string.subscription_notification_dialog_period_days
+    NotificationPeriod.WEEKS -> R.string.subscription_notification_dialog_period_weeks
+    NotificationPeriod.MONTHS -> R.string.subscription_notification_dialog_period_months
+}
+
 private fun initialPeriodAndCount(daysBeforePayment: Int?): Pair<NotificationPeriod, Int> =
     when {
         daysBeforePayment == null -> Pair(NotificationPeriod.DAYS, 1)
@@ -110,11 +116,7 @@ fun NotificationConfigDialog(
     var period by remember { mutableStateOf(initialPeriod) }
     var periodExpanded by remember { mutableStateOf(false) }
 
-    val periodLabel = when (period) {
-        NotificationPeriod.DAYS -> stringResource(id = R.string.subscription_notification_dialog_period_days)
-        NotificationPeriod.WEEKS -> stringResource(id = R.string.subscription_notification_dialog_period_weeks)
-        NotificationPeriod.MONTHS -> stringResource(id = R.string.subscription_notification_dialog_period_months)
-    }
+    val periodLabel = stringResource(period.labelRes())
 
     AlertDialog(
         icon = {
@@ -162,7 +164,9 @@ fun NotificationConfigDialog(
                                         isOff = false
                                     }
                                 },
-                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                keyboardOptions = KeyboardOptions(
+                                    keyboardType = KeyboardType.Number,
+                                ),
                                 modifier = Modifier.weight(1f),
                                 singleLine = true,
                             )
@@ -190,19 +194,8 @@ fun NotificationConfigDialog(
                                     onDismissRequest = { periodExpanded = false },
                                 ) {
                                     NotificationPeriod.entries.forEach { p ->
-                                        val label = when (p) {
-                                            NotificationPeriod.DAYS -> stringResource(
-                                                id = R.string.subscription_notification_dialog_period_days,
-                                            )
-                                            NotificationPeriod.WEEKS -> stringResource(
-                                                id = R.string.subscription_notification_dialog_period_weeks,
-                                            )
-                                            NotificationPeriod.MONTHS -> stringResource(
-                                                id = R.string.subscription_notification_dialog_period_months,
-                                            )
-                                        }
                                         DropdownMenuItem(
-                                            text = { Text(text = label) },
+                                            text = { Text(text = stringResource(p.labelRes())) },
                                             onClick = {
                                                 period = p
                                                 periodExpanded = false

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -56,6 +56,7 @@ private enum class NotificationMode { OFF, SAME_DAY, BEFORE }
 
 private const val DAYS_IN_WEEK = 7
 private const val APPROX_DAYS_IN_MONTH = 30
+private const val INPUT_FIELD_WEIGHT = 0.5f
 
 private fun NotificationPeriod.labelRes(): Int =
     when (this) {
@@ -64,11 +65,12 @@ private fun NotificationPeriod.labelRes(): Int =
         NotificationPeriod.MONTHS -> R.string.subscription_notification_dialog_period_months
     }
 
-private fun initialMode(config: NotificationConfig?): NotificationMode = when {
-    config == null -> NotificationMode.OFF
-    config.daysBeforePayment == 0 -> NotificationMode.SAME_DAY
-    else -> NotificationMode.BEFORE
-}
+private fun initialMode(config: NotificationConfig?): NotificationMode =
+    when {
+        config == null -> NotificationMode.OFF
+        config.daysBeforePayment == 0 -> NotificationMode.SAME_DAY
+        else -> NotificationMode.BEFORE
+    }
 
 private fun initialPeriodAndCount(daysBeforePayment: Int): Pair<NotificationPeriod, Int> =
     when {
@@ -159,130 +161,26 @@ fun NotificationConfigDialog(
             Text(stringResource(id = R.string.subscription_notification_dialog_title))
         },
         text = {
-            Column {
-                Spacer(modifier = Modifier.height(4.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { mode = NotificationMode.OFF }
-                        .padding(vertical = 4.dp),
-                ) {
-                    RadioButton(
-                        selected = mode == NotificationMode.OFF,
-                        onClick = { mode = NotificationMode.OFF },
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = stringResource(id = R.string.subscription_notification_dialog_off),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { mode = NotificationMode.SAME_DAY }
-                        .padding(vertical = 4.dp),
-                ) {
-                    RadioButton(
-                        selected = mode == NotificationMode.SAME_DAY,
-                        onClick = { mode = NotificationMode.SAME_DAY },
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = stringResource(
-                            id = R.string.subscription_notification_dialog_same_day,
-                        ),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
-                ) {
-                    RadioButton(
-                        selected = mode == NotificationMode.BEFORE,
-                        onClick = { mode = NotificationMode.BEFORE },
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            val digitsOnlyTextFieldFilter = rememberDigitsFilter {
-                                countText = it
-                                mode = NotificationMode.BEFORE
-                            }
-                            OutlinedTextField(
-                                value = countText,
-                                onValueChange = digitsOnlyTextFieldFilter,
-                                keyboardOptions = KeyboardOptions(
-                                    keyboardType = KeyboardType.Number,
-                                ),
-                                modifier = Modifier.weight(0.5f),
-                                singleLine = true,
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            ExposedDropdownMenuBox(
-                                expanded = periodExpanded,
-                                onExpandedChange = { periodExpanded = it },
-                                modifier = Modifier.weight(0.5f),
-                            ) {
-                                OutlinedTextField(
-                                    value = periodLabel,
-                                    onValueChange = {},
-                                    readOnly = true,
-                                    trailingIcon = {
-                                        ExposedDropdownMenuDefaults.TrailingIcon(
-                                            expanded = periodExpanded,
-                                        )
-                                    },
-                                    modifier = Modifier.menuAnchor(
-                                        ExposedDropdownMenuAnchorType.PrimaryNotEditable,
-                                    ),
-                                    singleLine = true,
-                                )
-                                ExposedDropdownMenu(
-                                    expanded = periodExpanded,
-                                    onDismissRequest = { periodExpanded = false },
-                                ) {
-                                    NotificationPeriod.entries.forEach { p ->
-                                        DropdownMenuItem(
-                                            text = {
-                                                Text(text = stringResource(p.labelRes()))
-                                            },
-                                            onClick = {
-                                                period = p
-                                                periodExpanded = false
-                                                mode = NotificationMode.BEFORE
-                                            },
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = stringResource(
-                                id = R.string.subscription_notification_dialog_before_payment,
-                            ),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
+            NotificationModeSelector(
+                mode = mode,
+                onModeChange = { mode = it },
+                countText = countText,
+                onCountChange = { countText = it },
+                onPeriodChange = { period = it },
+                periodExpanded = periodExpanded,
+                onPeriodExpandedChange = { periodExpanded = it },
+                periodLabel = periodLabel,
+            )
         },
         confirmButton = {
             TextButton(
                 onClick = {
                     when (mode) {
                         NotificationMode.OFF -> requestPermissionAndConfirm(null)
+
                         NotificationMode.SAME_DAY ->
                             requestPermissionAndConfirm(NotificationConfig(daysBeforePayment = 0))
+
                         NotificationMode.BEFORE -> {
                             val count = countText.toIntOrNull()?.coerceAtLeast(1) ?: 1
                             val days = when (period) {
@@ -290,7 +188,9 @@ fun NotificationConfigDialog(
                                 NotificationPeriod.WEEKS -> count * DAYS_IN_WEEK
                                 NotificationPeriod.MONTHS -> count * APPROX_DAYS_IN_MONTH
                             }
-                            requestPermissionAndConfirm(NotificationConfig(daysBeforePayment = days))
+                            requestPermissionAndConfirm(
+                                NotificationConfig(daysBeforePayment = days),
+                            )
                         }
                     }
                 },
@@ -317,6 +217,158 @@ fun NotificationConfigDialog(
                 context.startActivity(intent)
             },
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NotificationModeSelector(
+    mode: NotificationMode,
+    onModeChange: (NotificationMode) -> Unit,
+    countText: String,
+    onCountChange: (String) -> Unit,
+    onPeriodChange: (NotificationPeriod) -> Unit,
+    periodExpanded: Boolean,
+    onPeriodExpandedChange: (Boolean) -> Unit,
+    periodLabel: String,
+) {
+    Column {
+        Spacer(modifier = Modifier.height(4.dp))
+        ModeRadioRow(
+            selected = mode == NotificationMode.OFF,
+            onSelect = { onModeChange(NotificationMode.OFF) },
+            label = stringResource(id = R.string.subscription_notification_dialog_off),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        ModeRadioRow(
+            selected = mode == NotificationMode.SAME_DAY,
+            onSelect = { onModeChange(NotificationMode.SAME_DAY) },
+            label = stringResource(id = R.string.subscription_notification_dialog_same_day),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        BeforePaymentRow(
+            selected = mode == NotificationMode.BEFORE,
+            onSelect = { onModeChange(NotificationMode.BEFORE) },
+            countText = countText,
+            onCountChange = {
+                onCountChange(it)
+                onModeChange(NotificationMode.BEFORE)
+            },
+            onPeriodChange = {
+                onPeriodChange(it)
+                onModeChange(NotificationMode.BEFORE)
+            },
+            periodExpanded = periodExpanded,
+            onPeriodExpandedChange = onPeriodExpandedChange,
+            periodLabel = periodLabel,
+        )
+    }
+}
+
+@Composable
+private fun ModeRadioRow(selected: Boolean, onSelect: () -> Unit, label: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onSelect)
+            .padding(vertical = 4.dp),
+    ) {
+        RadioButton(selected = selected, onClick = onSelect)
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = label, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BeforePaymentRow(
+    selected: Boolean,
+    onSelect: () -> Unit,
+    countText: String,
+    onCountChange: (String) -> Unit,
+    onPeriodChange: (NotificationPeriod) -> Unit,
+    periodExpanded: Boolean,
+    onPeriodExpandedChange: (Boolean) -> Unit,
+    periodLabel: String,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+    ) {
+        RadioButton(selected = selected, onClick = onSelect)
+        Spacer(modifier = Modifier.width(8.dp))
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                val digitsOnlyTextFieldFilter = rememberDigitsFilter(onCountChange)
+                OutlinedTextField(
+                    value = countText,
+                    onValueChange = digitsOnlyTextFieldFilter,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(INPUT_FIELD_WEIGHT),
+                    singleLine = true,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                PeriodDropdown(
+                    onPeriodChange = onPeriodChange,
+                    expanded = periodExpanded,
+                    onExpandedChange = onPeriodExpandedChange,
+                    periodLabel = periodLabel,
+                    modifier = Modifier.weight(INPUT_FIELD_WEIGHT),
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(
+                    id = R.string.subscription_notification_dialog_before_payment,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PeriodDropdown(
+    onPeriodChange: (NotificationPeriod) -> Unit,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    periodLabel: String,
+    modifier: Modifier = Modifier,
+) {
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = onExpandedChange,
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = periodLabel,
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+            },
+            modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+            singleLine = true,
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { onExpandedChange(false) },
+        ) {
+            NotificationPeriod.entries.forEach { entry ->
+                DropdownMenuItem(
+                    text = { Text(text = stringResource(entry.labelRes())) },
+                    onClick = {
+                        onPeriodChange(entry)
+                        onExpandedChange(false)
+                    },
+                )
+            }
+        }
     }
 }
 

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -1,0 +1,88 @@
+package dev.pott.abonity.feature.subscription.detail.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
+import dev.pott.abonity.core.ui.R
+import dev.pott.abonity.core.ui.theme.AppIcons
+
+private val NOTIFICATION_OPTIONS = listOf(null, 0, 1, 2, 3, 7)
+
+@Composable
+fun NotificationConfigDialog(
+    currentConfig: NotificationConfig?,
+    onConfirm: (NotificationConfig?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        icon = {
+            Icon(
+                painter = rememberVectorPainter(image = AppIcons.Notification),
+                contentDescription = null,
+            )
+        },
+        title = {
+            Text(stringResource(id = R.string.subscription_notification_dialog_title))
+        },
+        text = {
+            Column {
+                Spacer(modifier = Modifier.height(4.dp))
+                NOTIFICATION_OPTIONS.forEach { days ->
+                    val label = when (days) {
+                        null -> stringResource(id = R.string.subscription_notification_dialog_off)
+                        0 -> stringResource(id = R.string.subscription_notification_dialog_same_day)
+                        1 -> stringResource(id = R.string.subscription_notification_dialog_one_day_before)
+                        7 -> stringResource(id = R.string.subscription_notification_dialog_one_week_before)
+                        else -> stringResource(
+                            id = R.string.subscription_notification_dialog_days_before,
+                            days,
+                        )
+                    }
+                    val isSelected = currentConfig?.daysBeforePayment == days
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onConfirm(days?.let { NotificationConfig(it) }) }
+                            .padding(vertical = 4.dp),
+                    ) {
+                        RadioButton(
+                            selected = isSelected,
+                            onClick = { onConfirm(days?.let { NotificationConfig(it) }) },
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(id = R.string.dialog_btn_dismiss_default))
+            }
+        },
+        onDismissRequest = onDismiss,
+    )
+}

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -14,11 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuAnchorType
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -34,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -46,42 +42,16 @@ import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.ui.R
 import dev.pott.abonity.core.ui.theme.AppIcons
 
-private enum class NotificationPeriod {
-    DAYS,
-    WEEKS,
-    MONTHS,
-}
-
 private enum class NotificationMode { OFF, SAME_DAY, BEFORE }
 
-private const val DAYS_IN_WEEK = 7
-private const val APPROX_DAYS_IN_MONTH = 30
-private const val INPUT_FIELD_WEIGHT = 0.5f
-
-private fun NotificationPeriod.labelRes(): Int =
-    when (this) {
-        NotificationPeriod.DAYS -> R.string.subscription_notification_dialog_period_days
-        NotificationPeriod.WEEKS -> R.string.subscription_notification_dialog_period_weeks
-        NotificationPeriod.MONTHS -> R.string.subscription_notification_dialog_period_months
-    }
+private const val COUNT_FIELD_WEIGHT = 0.4f
+private const val LABEL_WEIGHT = 0.6f
 
 private fun initialMode(config: NotificationConfig?): NotificationMode =
     when {
         config == null -> NotificationMode.OFF
         config.daysBeforePayment == 0 -> NotificationMode.SAME_DAY
         else -> NotificationMode.BEFORE
-    }
-
-private fun initialPeriodAndCount(daysBeforePayment: Int): Pair<NotificationPeriod, Int> =
-    when {
-        daysBeforePayment % APPROX_DAYS_IN_MONTH == 0 &&
-            daysBeforePayment >= APPROX_DAYS_IN_MONTH ->
-            Pair(NotificationPeriod.MONTHS, daysBeforePayment / APPROX_DAYS_IN_MONTH)
-
-        daysBeforePayment % DAYS_IN_WEEK == 0 && daysBeforePayment >= DAYS_IN_WEEK ->
-            Pair(NotificationPeriod.WEEKS, daysBeforePayment / DAYS_IN_WEEK)
-
-        else -> Pair(NotificationPeriod.DAYS, daysBeforePayment)
     }
 
 @OptIn(ExperimentalPermissionsApi::class)
@@ -124,7 +94,6 @@ private fun rememberRequestPermissionAndConfirm(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationConfigDialog(
     currentConfig: NotificationConfig?,
@@ -138,16 +107,11 @@ fun NotificationConfigDialog(
         onPermissionDeclined = { showPermissionDeclinedDialog = true },
     )
 
-    val (initialPeriod, initialCount) = remember(currentConfig) {
-        val days = currentConfig?.daysBeforePayment?.takeIf { it > 0 } ?: 1
-        initialPeriodAndCount(days)
+    val initialDays = remember(currentConfig) {
+        currentConfig?.daysBeforePayment?.takeIf { it > 0 } ?: 1
     }
     var mode by remember { mutableStateOf(initialMode(currentConfig)) }
-    var countText by remember { mutableStateOf(initialCount.toString()) }
-    var period by remember { mutableStateOf(initialPeriod) }
-    var periodExpanded by remember { mutableStateOf(false) }
-
-    val periodLabel = stringResource(period.labelRes())
+    var countText by remember { mutableStateOf(initialDays.toString()) }
 
     AlertDialog(
         properties = DialogProperties(usePlatformDefaultWidth = false),
@@ -166,10 +130,6 @@ fun NotificationConfigDialog(
                 onModeChange = { mode = it },
                 countText = countText,
                 onCountChange = { countText = it },
-                onPeriodChange = { period = it },
-                periodExpanded = periodExpanded,
-                onPeriodExpandedChange = { periodExpanded = it },
-                periodLabel = periodLabel,
             )
         },
         confirmButton = {
@@ -182,12 +142,7 @@ fun NotificationConfigDialog(
                             requestPermissionAndConfirm(NotificationConfig(daysBeforePayment = 0))
 
                         NotificationMode.BEFORE -> {
-                            val count = countText.toIntOrNull()?.coerceAtLeast(1) ?: 1
-                            val days = when (period) {
-                                NotificationPeriod.DAYS -> count
-                                NotificationPeriod.WEEKS -> count * DAYS_IN_WEEK
-                                NotificationPeriod.MONTHS -> count * APPROX_DAYS_IN_MONTH
-                            }
+                            val days = countText.toIntOrNull()?.coerceAtLeast(1) ?: 1
                             requestPermissionAndConfirm(
                                 NotificationConfig(daysBeforePayment = days),
                             )
@@ -220,17 +175,12 @@ fun NotificationConfigDialog(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun NotificationModeSelector(
     mode: NotificationMode,
     onModeChange: (NotificationMode) -> Unit,
     countText: String,
     onCountChange: (String) -> Unit,
-    onPeriodChange: (NotificationPeriod) -> Unit,
-    periodExpanded: Boolean,
-    onPeriodExpandedChange: (Boolean) -> Unit,
-    periodLabel: String,
 ) {
     Column {
         Spacer(modifier = Modifier.height(4.dp))
@@ -254,13 +204,6 @@ private fun NotificationModeSelector(
                 onCountChange(it)
                 onModeChange(NotificationMode.BEFORE)
             },
-            onPeriodChange = {
-                onPeriodChange(it)
-                onModeChange(NotificationMode.BEFORE)
-            },
-            periodExpanded = periodExpanded,
-            onPeriodExpandedChange = onPeriodExpandedChange,
-            periodLabel = periodLabel,
         )
     }
 }
@@ -280,18 +223,14 @@ private fun ModeRadioRow(selected: Boolean, onSelect: () -> Unit, label: String)
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BeforePaymentRow(
     selected: Boolean,
     onSelect: () -> Unit,
     countText: String,
     onCountChange: (String) -> Unit,
-    onPeriodChange: (NotificationPeriod) -> Unit,
-    periodExpanded: Boolean,
-    onPeriodExpandedChange: (Boolean) -> Unit,
-    periodLabel: String,
 ) {
+    val days = countText.toIntOrNull()?.coerceAtLeast(1) ?: 1
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -300,75 +239,23 @@ private fun BeforePaymentRow(
     ) {
         RadioButton(selected = selected, onClick = onSelect)
         Spacer(modifier = Modifier.width(8.dp))
-        Column {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                val digitsOnlyTextFieldFilter = rememberDigitsFilter(onCountChange)
-                OutlinedTextField(
-                    value = countText,
-                    onValueChange = digitsOnlyTextFieldFilter,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    modifier = Modifier.weight(INPUT_FIELD_WEIGHT),
-                    singleLine = true,
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                PeriodDropdown(
-                    onPeriodChange = onPeriodChange,
-                    expanded = periodExpanded,
-                    onExpandedChange = onPeriodExpandedChange,
-                    periodLabel = periodLabel,
-                    modifier = Modifier.weight(INPUT_FIELD_WEIGHT),
-                )
-            }
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(
-                    id = R.string.subscription_notification_dialog_before_payment,
-                ),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun PeriodDropdown(
-    onPeriodChange: (NotificationPeriod) -> Unit,
-    expanded: Boolean,
-    onExpandedChange: (Boolean) -> Unit,
-    periodLabel: String,
-    modifier: Modifier = Modifier,
-) {
-    ExposedDropdownMenuBox(
-        expanded = expanded,
-        onExpandedChange = onExpandedChange,
-        modifier = modifier,
-    ) {
+        val digitsOnlyTextFieldFilter = rememberDigitsFilter(onCountChange)
         OutlinedTextField(
-            value = periodLabel,
-            onValueChange = {},
-            readOnly = true,
-            trailingIcon = {
-                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-            },
-            modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+            value = countText,
+            onValueChange = digitsOnlyTextFieldFilter,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.weight(COUNT_FIELD_WEIGHT),
             singleLine = true,
         )
-        ExposedDropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { onExpandedChange(false) },
-        ) {
-            NotificationPeriod.entries.forEach { entry ->
-                DropdownMenuItem(
-                    text = { Text(text = stringResource(entry.labelRes())) },
-                    onClick = {
-                        onPeriodChange(entry)
-                        onExpandedChange(false)
-                    },
-                )
-            }
-        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = pluralStringResource(
+                id = R.plurals.subscription_notification_dialog_days_before_payment,
+                count = days,
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(LABEL_WEIGHT),
+        )
     }
 }
 

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -76,15 +76,12 @@ private fun initialPeriodAndCount(daysBeforePayment: Int?): Pair<NotificationPer
         else -> Pair(NotificationPeriod.DAYS, daysBeforePayment)
     }
 
-@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun NotificationConfigDialog(
-    currentConfig: NotificationConfig?,
+private fun rememberRequestPermissionAndConfirm(
     onConfirm: (NotificationConfig?) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val context = LocalContext.current
-    var showPermissionDeclinedDialog by remember { mutableStateOf(false) }
+    onPermissionDeclined: () -> Unit,
+): (NotificationConfig?) -> Unit {
     var pendingConfig by remember { mutableStateOf<NotificationConfig?>(null) }
     var isWaitingForPermission by remember { mutableStateOf(false) }
 
@@ -96,7 +93,7 @@ fun NotificationConfigDialog(
                     isWaitingForPermission = false
                     onConfirm(pendingConfig)
                     if (!isGranted) {
-                        showPermissionDeclinedDialog = true
+                        onPermissionDeclined()
                     }
                 }
             },
@@ -105,7 +102,7 @@ fun NotificationConfigDialog(
         null
     }
 
-    val requestPermissionAndConfirm: (NotificationConfig?) -> Unit = { config ->
+    return { config ->
         if (config != null &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             notificationPermissionState?.status?.isGranted == false
@@ -117,6 +114,21 @@ fun NotificationConfigDialog(
             onConfirm(config)
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationConfigDialog(
+    currentConfig: NotificationConfig?,
+    onConfirm: (NotificationConfig?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    var showPermissionDeclinedDialog by remember { mutableStateOf(false) }
+    val requestPermissionAndConfirm = rememberRequestPermissionAndConfirm(
+        onConfirm = onConfirm,
+        onPermissionDeclined = { showPermissionDeclinedDialog = true },
+    )
 
     val (initialPeriod, initialCount) = remember(currentConfig) {
         initialPeriodAndCount(currentConfig?.daysBeforePayment)

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -52,6 +52,8 @@ private enum class NotificationPeriod {
     MONTHS,
 }
 
+private enum class NotificationMode { OFF, SAME_DAY, BEFORE }
+
 private const val DAYS_IN_WEEK = 7
 private const val APPROX_DAYS_IN_MONTH = 30
 
@@ -62,10 +64,14 @@ private fun NotificationPeriod.labelRes(): Int =
         NotificationPeriod.MONTHS -> R.string.subscription_notification_dialog_period_months
     }
 
-private fun initialPeriodAndCount(daysBeforePayment: Int?): Pair<NotificationPeriod, Int> =
-    when {
-        daysBeforePayment == null -> Pair(NotificationPeriod.DAYS, 1)
+private fun initialMode(config: NotificationConfig?): NotificationMode = when {
+    config == null -> NotificationMode.OFF
+    config.daysBeforePayment == 0 -> NotificationMode.SAME_DAY
+    else -> NotificationMode.BEFORE
+}
 
+private fun initialPeriodAndCount(daysBeforePayment: Int): Pair<NotificationPeriod, Int> =
+    when {
         daysBeforePayment % APPROX_DAYS_IN_MONTH == 0 &&
             daysBeforePayment >= APPROX_DAYS_IN_MONTH ->
             Pair(NotificationPeriod.MONTHS, daysBeforePayment / APPROX_DAYS_IN_MONTH)
@@ -131,9 +137,10 @@ fun NotificationConfigDialog(
     )
 
     val (initialPeriod, initialCount) = remember(currentConfig) {
-        initialPeriodAndCount(currentConfig?.daysBeforePayment)
+        val days = currentConfig?.daysBeforePayment?.takeIf { it > 0 } ?: 1
+        initialPeriodAndCount(days)
     }
-    var isOff by remember { mutableStateOf(currentConfig == null) }
+    var mode by remember { mutableStateOf(initialMode(currentConfig)) }
     var countText by remember { mutableStateOf(initialCount.toString()) }
     var period by remember { mutableStateOf(initialPeriod) }
     var periodExpanded by remember { mutableStateOf(false) }
@@ -158,10 +165,13 @@ fun NotificationConfigDialog(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { isOff = true }
+                        .clickable { mode = NotificationMode.OFF }
                         .padding(vertical = 4.dp),
                 ) {
-                    RadioButton(selected = isOff, onClick = { isOff = true })
+                    RadioButton(
+                        selected = mode == NotificationMode.OFF,
+                        onClick = { mode = NotificationMode.OFF },
+                    )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = stringResource(id = R.string.subscription_notification_dialog_off),
@@ -173,15 +183,38 @@ fun NotificationConfigDialog(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .clickable { mode = NotificationMode.SAME_DAY }
                         .padding(vertical = 4.dp),
                 ) {
-                    RadioButton(selected = !isOff, onClick = { isOff = false })
+                    RadioButton(
+                        selected = mode == NotificationMode.SAME_DAY,
+                        onClick = { mode = NotificationMode.SAME_DAY },
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(
+                            id = R.string.subscription_notification_dialog_same_day,
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                ) {
+                    RadioButton(
+                        selected = mode == NotificationMode.BEFORE,
+                        onClick = { mode = NotificationMode.BEFORE },
+                    )
                     Spacer(modifier = Modifier.width(8.dp))
                     Column {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             val digitsOnlyTextFieldFilter = rememberDigitsFilter {
                                 countText = it
-                                isOff = false
+                                mode = NotificationMode.BEFORE
                             }
                             OutlinedTextField(
                                 value = countText,
@@ -224,7 +257,7 @@ fun NotificationConfigDialog(
                                             onClick = {
                                                 period = p
                                                 periodExpanded = false
-                                                isOff = false
+                                                mode = NotificationMode.BEFORE
                                             },
                                         )
                                     }
@@ -246,16 +279,19 @@ fun NotificationConfigDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    if (isOff) {
-                        requestPermissionAndConfirm(null)
-                    } else {
-                        val count = countText.toIntOrNull()?.coerceAtLeast(0) ?: 1
-                        val days = when (period) {
-                            NotificationPeriod.DAYS -> count
-                            NotificationPeriod.WEEKS -> count * DAYS_IN_WEEK
-                            NotificationPeriod.MONTHS -> count * APPROX_DAYS_IN_MONTH
+                    when (mode) {
+                        NotificationMode.OFF -> requestPermissionAndConfirm(null)
+                        NotificationMode.SAME_DAY ->
+                            requestPermissionAndConfirm(NotificationConfig(daysBeforePayment = 0))
+                        NotificationMode.BEFORE -> {
+                            val count = countText.toIntOrNull()?.coerceAtLeast(1) ?: 1
+                            val days = when (period) {
+                                NotificationPeriod.DAYS -> count
+                                NotificationPeriod.WEEKS -> count * DAYS_IN_WEEK
+                                NotificationPeriod.MONTHS -> count * APPROX_DAYS_IN_MONTH
+                            }
+                            requestPermissionAndConfirm(NotificationConfig(daysBeforePayment = days))
                         }
-                        requestPermissionAndConfirm(NotificationConfig(daysBeforePayment = days))
                     }
                 },
             ) {

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/detail/components/NotificationConfigDialog.kt
@@ -37,9 +37,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
+import dev.pott.abonity.common.text.rememberDigitsFilter
 import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.ui.R
 import dev.pott.abonity.core.ui.theme.AppIcons
@@ -53,19 +55,24 @@ private enum class NotificationPeriod {
 private const val DAYS_IN_WEEK = 7
 private const val APPROX_DAYS_IN_MONTH = 30
 
-private fun NotificationPeriod.labelRes(): Int = when (this) {
-    NotificationPeriod.DAYS -> R.string.subscription_notification_dialog_period_days
-    NotificationPeriod.WEEKS -> R.string.subscription_notification_dialog_period_weeks
-    NotificationPeriod.MONTHS -> R.string.subscription_notification_dialog_period_months
-}
+private fun NotificationPeriod.labelRes(): Int =
+    when (this) {
+        NotificationPeriod.DAYS -> R.string.subscription_notification_dialog_period_days
+        NotificationPeriod.WEEKS -> R.string.subscription_notification_dialog_period_weeks
+        NotificationPeriod.MONTHS -> R.string.subscription_notification_dialog_period_months
+    }
 
 private fun initialPeriodAndCount(daysBeforePayment: Int?): Pair<NotificationPeriod, Int> =
     when {
         daysBeforePayment == null -> Pair(NotificationPeriod.DAYS, 1)
-        daysBeforePayment % APPROX_DAYS_IN_MONTH == 0 && daysBeforePayment >= APPROX_DAYS_IN_MONTH ->
+
+        daysBeforePayment % APPROX_DAYS_IN_MONTH == 0 &&
+            daysBeforePayment >= APPROX_DAYS_IN_MONTH ->
             Pair(NotificationPeriod.MONTHS, daysBeforePayment / APPROX_DAYS_IN_MONTH)
+
         daysBeforePayment % DAYS_IN_WEEK == 0 && daysBeforePayment >= DAYS_IN_WEEK ->
             Pair(NotificationPeriod.WEEKS, daysBeforePayment / DAYS_IN_WEEK)
+
         else -> Pair(NotificationPeriod.DAYS, daysBeforePayment)
     }
 
@@ -122,6 +129,7 @@ fun NotificationConfigDialog(
     val periodLabel = stringResource(period.labelRes())
 
     AlertDialog(
+        properties = DialogProperties(usePlatformDefaultWidth = false),
         icon = {
             Icon(
                 painter = rememberVectorPainter(image = AppIcons.Notification),
@@ -159,24 +167,24 @@ fun NotificationConfigDialog(
                     Spacer(modifier = Modifier.width(8.dp))
                     Column {
                         Row(verticalAlignment = Alignment.CenterVertically) {
+                            val digitsOnlyTextFieldFilter = rememberDigitsFilter {
+                                countText = it
+                                isOff = false
+                            }
                             OutlinedTextField(
                                 value = countText,
-                                onValueChange = { input ->
-                                    if (input.all { it.isDigit() }) {
-                                        countText = input
-                                        isOff = false
-                                    }
-                                },
+                                onValueChange = digitsOnlyTextFieldFilter,
                                 keyboardOptions = KeyboardOptions(
                                     keyboardType = KeyboardType.Number,
                                 ),
-                                modifier = Modifier.weight(1f),
+                                modifier = Modifier.weight(0.5f),
                                 singleLine = true,
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             ExposedDropdownMenuBox(
                                 expanded = periodExpanded,
                                 onExpandedChange = { periodExpanded = it },
+                                modifier = Modifier.weight(0.5f),
                             ) {
                                 OutlinedTextField(
                                     value = periodLabel,
@@ -198,7 +206,9 @@ fun NotificationConfigDialog(
                                 ) {
                                     NotificationPeriod.entries.forEach { p ->
                                         DropdownMenuItem(
-                                            text = { Text(text = stringResource(p.labelRes())) },
+                                            text = {
+                                                Text(text = stringResource(p.labelRes()))
+                                            },
                                             onClick = {
                                                 period = p
                                                 periodExpanded = false

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/overview/OverviewRoute.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/overview/OverviewRoute.kt
@@ -53,6 +53,7 @@ fun OverviewRoute(
             onFilterItemSelect = overviewViewModel::toggleFilter,
             onEditClick = onEditClick,
             onDeleteClick = overviewViewModel::delete,
+            onNotificationConfigChanged = detailViewModel::setNotificationConfig,
             closeDetails = overviewViewModel::consumeDetails,
             onOpenCategoriesClick = onOpenCategoriesClick,
             onPeriodChange = overviewViewModel::setPeriod,
@@ -89,6 +90,7 @@ fun OverviewRoute(
                 onEditClick = onEditClick,
                 onDeleteClick = overviewViewModel::delete,
                 close = overviewViewModel::consumeDetails,
+                onNotificationConfigChanged = detailViewModel::setNotificationConfig,
             )
         }
     }

--- a/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/overview/OverviewScreenWithDetails.kt
+++ b/feature/subscription/src/main/kotlin/dev/pott/abonity/feature/subscription/overview/OverviewScreenWithDetails.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.pott.abonity.core.entity.subscription.Category
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.PaymentInfo
 import dev.pott.abonity.core.entity.subscription.PaymentPeriod
 import dev.pott.abonity.core.entity.subscription.PaymentType
@@ -52,6 +53,7 @@ fun OverviewScreenWithDetails(
     onFilterItemSelect: (item: SubscriptionFilterItem) -> Unit,
     onEditClick: (id: SubscriptionId) -> Unit,
     onDeleteClick: (id: SubscriptionId) -> Unit,
+    onNotificationConfigChanged: (NotificationConfig?) -> Unit,
     closeDetails: () -> Unit,
     onOpenCategoriesClick: () -> Unit,
     onPeriodChange: (period: PaymentPeriod) -> Unit,
@@ -84,6 +86,7 @@ fun OverviewScreenWithDetails(
                 },
                 onEditClick = onEditClick,
                 onDeleteClick = onDeleteClick,
+                onNotificationConfigChanged = onNotificationConfigChanged,
                 modifier = Modifier.weight(1f),
             )
         }
@@ -178,6 +181,7 @@ private fun OverviewWithDetailScreenPreview() {
             onFilterItemSelect = {},
             onEditClick = {},
             onDeleteClick = {},
+            onNotificationConfigChanged = {},
             closeDetails = {},
             onOpenCategoriesClick = {},
             onPeriodChange = {},

--- a/feature/subscription/src/test/kotlin/dev/pott/abonity/feature/subscription/detail/DetailViewModelTest.kt
+++ b/feature/subscription/src/test/kotlin/dev/pott/abonity/feature/subscription/detail/DetailViewModelTest.kt
@@ -4,11 +4,14 @@ import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import dev.pott.abonity.common.test.CoroutinesTestExtension
 import dev.pott.abonity.core.domain.FakeClock
 import dev.pott.abonity.core.domain.subscription.FakeSubscriptionRepository
 import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
+import dev.pott.abonity.core.domain.subscription.entities.createTestSubscription
 import dev.pott.abonity.core.domain.subscription.entities.createTestSubscriptionList
+import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.SubscriptionId
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -69,6 +72,67 @@ class DetailViewModelTest {
                 tested.setId(SubscriptionId(100))
                 assertThat(cancelAndConsumeRemainingEvents()).isEmpty()
             }
+        }
+    }
+
+    @Test
+    fun `GIVEN loaded subscription WHEN setNotificationConfig with config THEN subscription is saved with config`() {
+        runTest {
+            val subscription = createTestSubscription()
+            val subscriptionRepository = FakeSubscriptionRepository(
+                subscriptionFlow = flowOf(subscription),
+            )
+            val tested = DetailViewModel(subscriptionRepository, PaymentInfoCalculator(FakeClock()))
+
+            tested.state.test {
+                assertThat(awaitItem()).isEqualTo(DetailState())
+                tested.setId(subscription.id)
+                awaitItem() // consume the loaded state
+
+                val config = NotificationConfig(daysBeforePayment = 3)
+                tested.setNotificationConfig(config)
+
+                assertThat(subscriptionRepository.addedSubscriptions.last())
+                    .isEqualTo(subscription.copy(notificationConfig = config))
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN loaded subscription with config WHEN setNotificationConfig with null THEN subscription is saved with no config`() {
+        runTest {
+            val subscription = createTestSubscription(
+                notificationConfig = NotificationConfig(daysBeforePayment = 1),
+            )
+            val subscriptionRepository = FakeSubscriptionRepository(
+                subscriptionFlow = flowOf(subscription),
+            )
+            val tested = DetailViewModel(subscriptionRepository, PaymentInfoCalculator(FakeClock()))
+
+            tested.state.test {
+                assertThat(awaitItem()).isEqualTo(DetailState())
+                tested.setId(subscription.id)
+                awaitItem() // consume the loaded state
+
+                tested.setNotificationConfig(null)
+
+                assertThat(subscriptionRepository.addedSubscriptions.last().notificationConfig)
+                    .isNull()
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN no subscription loaded WHEN setNotificationConfig THEN nothing is saved`() {
+        runTest {
+            val subscriptionRepository = FakeSubscriptionRepository()
+            val tested = DetailViewModel(subscriptionRepository, PaymentInfoCalculator(FakeClock()))
+
+            tested.setNotificationConfig(NotificationConfig(daysBeforePayment = 0))
+
+            assertThat(subscriptionRepository.addedSubscriptions).isEmpty()
         }
     }
 }

--- a/feature/subscription/src/test/kotlin/dev/pott/abonity/feature/subscription/detail/DetailViewModelTest.kt
+++ b/feature/subscription/src/test/kotlin/dev/pott/abonity/feature/subscription/detail/DetailViewModelTest.kt
@@ -7,13 +7,16 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
 import dev.pott.abonity.common.test.CoroutinesTestExtension
 import dev.pott.abonity.core.domain.FakeClock
+import dev.pott.abonity.core.domain.subscription.FakeSubscriptionNotificationScheduler
 import dev.pott.abonity.core.domain.subscription.FakeSubscriptionRepository
 import dev.pott.abonity.core.domain.subscription.PaymentInfoCalculator
 import dev.pott.abonity.core.domain.subscription.entities.createTestSubscription
 import dev.pott.abonity.core.domain.subscription.entities.createTestSubscriptionList
 import dev.pott.abonity.core.entity.subscription.NotificationConfig
 import dev.pott.abonity.core.entity.subscription.SubscriptionId
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -21,6 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.time.Instant
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutinesTestExtension::class)
 class DetailViewModelTest {
 
@@ -32,7 +36,11 @@ class DetailViewModelTest {
                 subscriptionFlow = flowOf(*subscriptions),
             )
 
-            val tested = DetailViewModel(subscriptionRepository, PaymentInfoCalculator(FakeClock()))
+            val tested = DetailViewModel(
+                subscriptionRepository,
+                PaymentInfoCalculator(FakeClock()),
+                FakeSubscriptionNotificationScheduler(),
+            )
 
             tested.state.test {
                 assertThat(awaitItem()).isEqualTo(DetailState())
@@ -65,7 +73,11 @@ class DetailViewModelTest {
                 subscriptionFlow = flowOf(*subscriptions),
             )
 
-            val tested = DetailViewModel(subscriptionRepository, PaymentInfoCalculator(FakeClock()))
+            val tested = DetailViewModel(
+                subscriptionRepository,
+                PaymentInfoCalculator(FakeClock()),
+                FakeSubscriptionNotificationScheduler(),
+            )
 
             tested.state.test {
                 assertThat(awaitItem()).isEqualTo(DetailState())
@@ -76,13 +88,18 @@ class DetailViewModelTest {
     }
 
     @Test
-    fun `GIVEN loaded subscription WHEN setNotificationConfig with config THEN subscription is saved with config`() {
+    fun `GIVEN loaded subscription WHEN setNotificationConfig with config THEN subscription is saved with config AND scheduler is triggered`() {
         runTest {
             val subscription = createTestSubscription()
             val subscriptionRepository = FakeSubscriptionRepository(
                 subscriptionFlow = flowOf(subscription),
             )
-            val tested = DetailViewModel(subscriptionRepository, PaymentInfoCalculator(FakeClock()))
+            val scheduler = FakeSubscriptionNotificationScheduler()
+            val tested = DetailViewModel(
+                subscriptionRepository,
+                PaymentInfoCalculator(FakeClock()),
+                scheduler,
+            )
 
             tested.state.test {
                 assertThat(awaitItem()).isEqualTo(DetailState())
@@ -91,16 +108,18 @@ class DetailViewModelTest {
 
                 val config = NotificationConfig(daysBeforePayment = 3)
                 tested.setNotificationConfig(config)
+                runCurrent()
 
                 assertThat(subscriptionRepository.addedSubscriptions.last())
                     .isEqualTo(subscription.copy(notificationConfig = config))
+                assertThat(scheduler.immediateCheckCount).isEqualTo(1)
                 cancelAndConsumeRemainingEvents()
             }
         }
     }
 
     @Test
-    fun `GIVEN loaded subscription with config WHEN setNotificationConfig with null THEN subscription is saved with no config`() {
+    fun `GIVEN loaded subscription with config WHEN setNotificationConfig with null THEN subscription is saved with no config AND scheduler is not triggered`() {
         runTest {
             val subscription = createTestSubscription(
                 notificationConfig = NotificationConfig(daysBeforePayment = 1),
@@ -108,7 +127,12 @@ class DetailViewModelTest {
             val subscriptionRepository = FakeSubscriptionRepository(
                 subscriptionFlow = flowOf(subscription),
             )
-            val tested = DetailViewModel(subscriptionRepository, PaymentInfoCalculator(FakeClock()))
+            val scheduler = FakeSubscriptionNotificationScheduler()
+            val tested = DetailViewModel(
+                subscriptionRepository,
+                PaymentInfoCalculator(FakeClock()),
+                scheduler,
+            )
 
             tested.state.test {
                 assertThat(awaitItem()).isEqualTo(DetailState())
@@ -116,9 +140,11 @@ class DetailViewModelTest {
                 awaitItem() // consume the loaded state
 
                 tested.setNotificationConfig(null)
+                runCurrent()
 
                 assertThat(subscriptionRepository.addedSubscriptions.last().notificationConfig)
                     .isNull()
+                assertThat(scheduler.immediateCheckCount).isEqualTo(0)
                 cancelAndConsumeRemainingEvents()
             }
         }
@@ -128,7 +154,11 @@ class DetailViewModelTest {
     fun `GIVEN no subscription loaded WHEN setNotificationConfig THEN nothing is saved`() {
         runTest {
             val subscriptionRepository = FakeSubscriptionRepository()
-            val tested = DetailViewModel(subscriptionRepository, PaymentInfoCalculator(FakeClock()))
+            val tested = DetailViewModel(
+                subscriptionRepository,
+                PaymentInfoCalculator(FakeClock()),
+                FakeSubscriptionNotificationScheduler(),
+            )
 
             tested.setNotificationConfig(NotificationConfig(daysBeforePayment = 0))
 


### PR DESCRIPTION
- Add NotificationConfig entity to store days-before-payment setting
- Add notificationConfig field to Subscription entity (nullable, null = disabled)
- Update Room DB to version 2 with MIGRATION_1_2 for new column
- Add notification bell icon to subscription detail toolbar actions
- Create NotificationConfigDialog with options: off, same day, 1/2/3/7 days before
- Update DetailViewModel with setNotificationConfig method for persistence
- Create SubscriptionNotificationWorker (HiltWorker) that runs daily at 8 AM
  and sends one notification per subscription due for notification
- Register notification worker in AbonityApplication with 8 AM schedule
- Create notification channel for payment reminders

https://claude.ai/code/session_01X8sVBakB31jcUKj8TGXC4y